### PR TITLE
Fixed edit status update if there are no apprentices

### DIFF
--- a/src/SFA.DAS.Commitments.Application.UnitTests/Rules/ApprenticeshipUpdateRules/WhenDetermineNewEditStatus.cs
+++ b/src/SFA.DAS.Commitments.Application.UnitTests/Rules/ApprenticeshipUpdateRules/WhenDetermineNewEditStatus.cs
@@ -32,11 +32,11 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Rules.ApprenticeshipUpdateRu
             Assert.AreEqual(expectedEditStatus, _rules.DetermineNewEditStatus(EditStatus.Both, caller, true, 10));
         }
 
-        [TestCase(EditStatus.EmployerOnly, CallerType.Employer)]
-        [TestCase(EditStatus.ProviderOnly, CallerType.Provider)]
-        public void ThenLeaveAsIsIfThereAreNoApprenticeshipsInTheCommitment(EditStatus existingEditStatus, CallerType caller)
+        [TestCase(EditStatus.EmployerOnly, CallerType.Employer, EditStatus.ProviderOnly)]
+        [TestCase(EditStatus.ProviderOnly, CallerType.Provider, EditStatus.EmployerOnly)]
+        public void ThenSetToOtherPartyCanEditIfThereAreNoApprenticeshipsInTheCommitment(EditStatus existingEditStatus, CallerType caller, EditStatus expectedStatus)
         {
-            Assert.AreEqual(existingEditStatus, _rules.DetermineNewEditStatus(existingEditStatus, caller, false, 0));
+            Assert.AreEqual(expectedStatus, _rules.DetermineNewEditStatus(existingEditStatus, caller, false, 0));
         }
     }
 }

--- a/src/SFA.DAS.Commitments.Application/Rules/ApprenticeshipUpdateRules.cs
+++ b/src/SFA.DAS.Commitments.Application/Rules/ApprenticeshipUpdateRules.cs
@@ -56,10 +56,10 @@ namespace SFA.DAS.Commitments.Application.Rules
 
         public EditStatus DetermineNewEditStatus(EditStatus currentEditStatus, CallerType caller, bool areAnyApprenticeshipsPendingAgreement, int apprenticeshipsInCommitment)
         {
-            if (areAnyApprenticeshipsPendingAgreement)
+            if (areAnyApprenticeshipsPendingAgreement || apprenticeshipsInCommitment == 0)
                 return caller == CallerType.Provider ? EditStatus.EmployerOnly : EditStatus.ProviderOnly;
 
-            return apprenticeshipsInCommitment > 0 ? EditStatus.Both : currentEditStatus;
+            return EditStatus.Both;
         }
 
         public AgreementStatus DetermineNewAgreementStatus(AgreementStatus currentAgreementStatus, CallerType caller, LastAction action)


### PR DESCRIPTION
The test that is changed was saying that the EditStatus should remain the same if there were no apprentices. I'm not sure what scenario this would be?