### PR TITLE
Set cost to -1 on event when none provided

### DIFF
--- a/src/SFA.DAS.Commitments.Infrastructure.UnitTests/Services/ApprenticeshipEventsTests/ApprenticeshipEventsTestsBase.cs
+++ b/src/SFA.DAS.Commitments.Infrastructure.UnitTests/Services/ApprenticeshipEventsTests/ApprenticeshipEventsTestsBase.cs
@@ -62,7 +62,7 @@ namespace SFA.DAS.Commitments.Infrastructure.UnitTests.Services.ApprenticeshipEv
                    apprenticeshipEvent.ProviderId == Commitment.ProviderId.ToString() &&
                    apprenticeshipEvent.TrainingEndDate == Apprenticeship.EndDate &&
                    apprenticeshipEvent.TrainingStartDate == Apprenticeship.StartDate &&
-                   apprenticeshipEvent.TrainingTotalCost == Apprenticeship.Cost &&
+                   apprenticeshipEvent.TrainingTotalCost == (Apprenticeship.Cost ?? -1) &&
                    apprenticeshipEvent.TrainingType == (Apprenticeship.TrainingType == TrainingType.Framework ? TrainingTypes.Framework : TrainingTypes.Standard) &&
                    apprenticeshipEvent.PaymentOrder == Apprenticeship.PaymentOrder &&
                    apprenticeshipEvent.LegalEntityId == Commitment.LegalEntityId &&

--- a/src/SFA.DAS.Commitments.Infrastructure.UnitTests/Services/ApprenticeshipEventsTests/WhenIPublishAnEvent.cs
+++ b/src/SFA.DAS.Commitments.Infrastructure.UnitTests/Services/ApprenticeshipEventsTests/WhenIPublishAnEvent.cs
@@ -41,7 +41,17 @@ namespace SFA.DAS.Commitments.Infrastructure.UnitTests.Services.ApprenticeshipEv
 
             VerifyEventWasPublished(_event);
         }
-        
+
+        [Test]
+        public async Task AndTheTotalTrainingCostIsNotProvidedThenTheEventIsPublishedWithADefaultValue()
+        {
+            Apprenticeship.Cost = null;
+
+            await Service.PublishEvent(Commitment, Apprenticeship, _event);
+
+            VerifyEventWasPublished(_event);
+        }
+
         private void VerifyEventWasPublished(string @event)
         {
             CommitmentsLogger.Verify(x => x.Info($"Create apprenticeship event: {@event}", null, null, Commitment.Id, Apprenticeship.Id), Times.Once);

--- a/src/SFA.DAS.Commitments.Infrastructure/Services/ApprenticeshipEvents.cs
+++ b/src/SFA.DAS.Commitments.Infrastructure/Services/ApprenticeshipEvents.cs
@@ -93,7 +93,7 @@ namespace SFA.DAS.Commitments.Infrastructure.Services
                 ProviderId = commitment.ProviderId != null ? commitment.ProviderId.ToString() : string.Empty,
                 TrainingEndDate = apprenticeship.EndDate ?? DateTime.MaxValue,
                 TrainingStartDate = apprenticeship.StartDate ?? DateTime.MaxValue,
-                TrainingTotalCost = apprenticeship.Cost ?? decimal.MinValue,
+                TrainingTotalCost = apprenticeship.Cost ?? -1,
                 TrainingType = apprenticeship.TrainingType == TrainingType.Framework ? TrainingTypes.Framework : TrainingTypes.Standard,
                 PaymentOrder = apprenticeship.PaymentOrder,
                 LegalEntityId = commitment.LegalEntityId,


### PR DESCRIPTION
Using decimal.minvalue was causing the insert into the events database
to fail as the field wasn't big enough to hold the value.