### PR TITLE
Adds config option

### DIFF
--- a/src/SFA.DAS.CommitmentPayments.WebJob.UnitTests/SFA.DAS.CommitmentPayments.WebJob.UnitTests.csproj
+++ b/src/SFA.DAS.CommitmentPayments.WebJob.UnitTests/SFA.DAS.CommitmentPayments.WebJob.UnitTests.csproj
@@ -86,6 +86,10 @@
       <Project>{42c9280d-cdaa-45b8-9a02-eb629288798d}</Project>
       <Name>SFA.DAS.CommitmentPayments.WebJob</Name>
     </ProjectReference>
+    <ProjectReference Include="..\SFA.DAS.Commitments.Application\SFA.DAS.Commitments.Application.csproj">
+      <Project>{880cdaf6-d9ee-481b-b4d8-7de9c215a770}</Project>
+      <Name>SFA.DAS.Commitments.Application</Name>
+    </ProjectReference>
     <ProjectReference Include="..\SFA.DAS.Commitments.Domain\SFA.DAS.Commitments.Domain.csproj">
       <Project>{c4c803af-747e-4747-a23b-da43219009a4}</Project>
       <Name>SFA.DAS.Commitments.Domain</Name>

--- a/src/SFA.DAS.CommitmentPayments.WebJob/Configuration/CommitmentPaymentsConfiguration.cs
+++ b/src/SFA.DAS.CommitmentPayments.WebJob/Configuration/CommitmentPaymentsConfiguration.cs
@@ -16,6 +16,8 @@ namespace SFA.DAS.CommitmentPayments.WebJob.Configuration
         public bool UseDocumentRepository { get; set; }
 
         public string StorageConnectionString { get; set; }
+
+        public bool DisableApprenticeshipValidation { get; set; }
     }
 
     public class PaymentEventsApi : IPaymentsEventsApiConfiguration

--- a/src/SFA.DAS.CommitmentPayments.WebJob/Configuration/CommitmentPaymentsConfiguration.cs
+++ b/src/SFA.DAS.CommitmentPayments.WebJob/Configuration/CommitmentPaymentsConfiguration.cs
@@ -17,7 +17,7 @@ namespace SFA.DAS.CommitmentPayments.WebJob.Configuration
 
         public string StorageConnectionString { get; set; }
 
-        public bool DisableApprenticeshipValidation { get; set; }
+        public bool IgnoreDataLockStatusConstraintErrors { get; set; }
     }
 
     public class PaymentEventsApi : IPaymentsEventsApiConfiguration

--- a/src/SFA.DAS.CommitmentPayments.WebJob/DependencyResolution/DefaultRegistry.cs
+++ b/src/SFA.DAS.CommitmentPayments.WebJob/DependencyResolution/DefaultRegistry.cs
@@ -34,8 +34,10 @@ namespace SFA.DAS.CommitmentPayments.WebJob.DependencyResolution
                 .Ctor<IPaymentsEventsApiConfiguration>().Is(config.PaymentEventsApi);
 
             For<IConfiguration>().Use(config);
+            For<CommitmentPaymentsConfiguration>().Use(config);
             For<IDataLockRepository>().Use<DataLockRepository>().Ctor<string>().Is(config.DatabaseConnectionString);
             For<IApprenticeshipUpdateRepository>().Use<ApprenticeshipUpdateRepository>().Ctor<string>().Is(config.DatabaseConnectionString);
+            For<IApprenticeshipRepository>().Use<ApprenticeshipRepository>().Ctor<string>().Is(config.DatabaseConnectionString);
 
             For<IDataLockUpdater>().Use<DataLockUpdater>();
 

--- a/src/SFA.DAS.CommitmentPayments.WebJob/Updater/DataLockUpdater.cs
+++ b/src/SFA.DAS.CommitmentPayments.WebJob/Updater/DataLockUpdater.cs
@@ -4,12 +4,12 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using SFA.DAS.CommitmentPayments.WebJob.Configuration;
-using SFA.DAS.Commitments.Application.Exceptions;
 using SFA.DAS.Commitments.Domain.Data;
 using SFA.DAS.Commitments.Domain.Entities;
 using SFA.DAS.Commitments.Domain.Entities.DataLock;
 using SFA.DAS.Commitments.Domain.Interfaces;
 using SFA.DAS.NLog.Logger;
+using SFA.DAS.Commitments.Domain.Exceptions;
 
 namespace SFA.DAS.CommitmentPayments.WebJob.Updater
 {
@@ -20,7 +20,6 @@ namespace SFA.DAS.CommitmentPayments.WebJob.Updater
         private readonly IPaymentEvents _paymentEventsSerivce;
         private readonly IDataLockRepository _dataLockRepository;
         private readonly IApprenticeshipUpdateRepository _apprenticeshipUpdateRepository;
-        private readonly IApprenticeshipRepository _apprenticeshipRepository;
         private readonly CommitmentPaymentsConfiguration _config;
 
         private readonly IList<DataLockErrorCode> _whiteList;
@@ -29,7 +28,6 @@ namespace SFA.DAS.CommitmentPayments.WebJob.Updater
             IPaymentEvents paymentEventsService,
             IDataLockRepository dataLockRepository,
             IApprenticeshipUpdateRepository apprenticeshipUpdateRepository,
-            IApprenticeshipRepository apprenticeshipRepository,
             CommitmentPaymentsConfiguration config)
         {
             if(logger==null)
@@ -40,8 +38,6 @@ namespace SFA.DAS.CommitmentPayments.WebJob.Updater
                 throw new ArgumentNullException(nameof(IDataLockRepository));
             if(apprenticeshipUpdateRepository == null)
                 throw new ArgumentNullException(nameof(IApprenticeshipUpdateRepository));
-            if(apprenticeshipRepository == null)
-                throw new ArgumentNullException(nameof(IApprenticeshipRepository));
             if(config == null)
                 throw new ArgumentNullException(nameof(CommitmentPaymentsConfiguration));
 
@@ -49,7 +45,6 @@ namespace SFA.DAS.CommitmentPayments.WebJob.Updater
             _paymentEventsSerivce = paymentEventsService;
             _dataLockRepository = dataLockRepository;
             _apprenticeshipUpdateRepository = apprenticeshipUpdateRepository;
-            _apprenticeshipRepository = apprenticeshipRepository;
             _config = config;
 
             _whiteList = new List<DataLockErrorCode>
@@ -101,18 +96,6 @@ namespace SFA.DAS.CommitmentPayments.WebJob.Updater
                         _logger.Info($"Updating Apprenticeship {dataLockStatus.ApprenticeshipId} " +
                              $"Event Id {dataLockStatus.DataLockEventId} Status {dataLockStatus.ErrorCode}");
 
-                        //depending on config setting, check that the apprenticeship exists
-                        if (!_config.DisableApprenticeshipValidation)
-                        {
-                            var apprenticeship = await
-                                _apprenticeshipRepository.GetApprenticeship(dataLockStatus.ApprenticeshipId);
-
-                            if (apprenticeship == null)
-                            {
-                                throw new ResourceNotFoundException($"Apprenticeship {dataLockStatus.ApprenticeshipId} referenced in Event Id { dataLockStatus.DataLockEventId} does not exist in DAS");
-                            }
-                        }
-
                         var pendingApprenticeshipUpdate =
                         await _apprenticeshipUpdateRepository.GetPendingApprenticeshipUpdate(dataLockStatus.ApprenticeshipId);
 
@@ -120,8 +103,14 @@ namespace SFA.DAS.CommitmentPayments.WebJob.Updater
                         {
                             await _apprenticeshipUpdateRepository.SupercedeApprenticeshipUpdate(dataLockStatus.ApprenticeshipId);
                         }
-                       
-                        await _dataLockRepository.UpdateDataLockStatus(dataLockStatus);
+
+                        try
+                        {
+                            await _dataLockRepository.UpdateDataLockStatus(dataLockStatus);
+                        }
+                        catch(RepositoryConstraintException) when (_config.IgnoreDataLockStatusConstraintErrors)
+                        {
+                        }
                     }
 
                     lastId = dataLockStatus.DataLockEventId;

--- a/src/SFA.DAS.Commitments.Database/Tables/DataLockStatus.sql
+++ b/src/SFA.DAS.Commitments.Database/Tables/DataLockStatus.sql
@@ -15,6 +15,7 @@
     [TriageStatus] TINYINT NOT NULL,
 	[ApprenticeshipUpdateId] BIGINT NULL,
 	[IsResolved] BIT NOT NULL,
+	CONSTRAINT [FK_DataLockStatus_ApprenticeshipId] FOREIGN KEY ([ApprenticeshipId]) REFERENCES [Apprenticeship]([Id]),
 	CONSTRAINT [FK_DataLockStatus_ApprenticeshipUpdateId] FOREIGN KEY ([ApprenticeshipUpdateId]) REFERENCES [ApprenticeshipUpdate]([Id])
 )
 GO

--- a/src/SFA.DAS.Commitments.Database/Tables/DataLockStatus.sql
+++ b/src/SFA.DAS.Commitments.Database/Tables/DataLockStatus.sql
@@ -15,7 +15,6 @@
     [TriageStatus] TINYINT NOT NULL,
 	[ApprenticeshipUpdateId] BIGINT NULL,
 	[IsResolved] BIT NOT NULL,
-	CONSTRAINT [FK_DataLockStatus_ApprenticeshipId] FOREIGN KEY ([ApprenticeshipId]) REFERENCES [Apprenticeship]([Id]),
 	CONSTRAINT [FK_DataLockStatus_ApprenticeshipUpdateId] FOREIGN KEY ([ApprenticeshipUpdateId]) REFERENCES [ApprenticeshipUpdate]([Id])
 )
 GO

--- a/src/SFA.DAS.Commitments.Domain/Exceptions/RepositoryConstraintException.cs
+++ b/src/SFA.DAS.Commitments.Domain/Exceptions/RepositoryConstraintException.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace SFA.DAS.Commitments.Domain.Exceptions
+{
+    [Serializable]
+    public class RepositoryConstraintException : Exception
+    {
+        public RepositoryConstraintException() { }
+
+        public RepositoryConstraintException(string message) : base(message) { }
+
+        public RepositoryConstraintException(string message, Exception inner) : base(message, inner) { }
+
+        protected RepositoryConstraintException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+}

--- a/src/SFA.DAS.Commitments.Domain/SFA.DAS.Commitments.Domain.csproj
+++ b/src/SFA.DAS.Commitments.Domain/SFA.DAS.Commitments.Domain.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Data\ICommitmentRepository.cs" />
     <Compile Include="Entities\Relationship.cs" />
     <Compile Include="Entities\UpdateOrigin.cs" />
+    <Compile Include="Exceptions\RepositoryConstraintException.cs" />
     <Compile Include="Extensions\ApprenticeshipExtensions.cs" />
     <Compile Include="Extensions\DataLockExtensions.cs" />
     <Compile Include="Extensions\IEnumerableExtension.cs" />


### PR DESCRIPTION
Needs new option to be added to config repo json. Validation performed by default (as currently), so test environment needs config option explicitly set to "true" by exception.

Not for merge until Sat has cut a release branch for data lock v2.

DCM-736