### PR TITLE
Dcm 629 pagination

### DIFF
--- a/src/SFA.DAS.Commitments.Api.UnitTests/Orchestrators/Employer/WhenGettingApprenticeshipSearch.cs
+++ b/src/SFA.DAS.Commitments.Api.UnitTests/Orchestrators/Employer/WhenGettingApprenticeshipSearch.cs
@@ -56,7 +56,7 @@ namespace SFA.DAS.Commitments.Api.UnitTests.Orchestrators.Employer
             // Return same IList<Apprenticeship> as input.
             _mockApprenticeshipFilter.Setup(m => 
                 m.Filter(It.IsAny<IList<Apprenticeship>>(), It.IsAny<ApprenticeshipSearchQuery>(), Originator.Employer))
-                .Returns<IList<Apprenticeship>, ApprenticeshipSearchQuery,Originator>((aps, q, o) => aps);
+                .Returns<IList<Apprenticeship>, ApprenticeshipSearchQuery,Originator>((aps, q, o) => new FilterResult(aps.ToList(), 1, 25));
 
             var result = await _orchestrator.GetApprenticeships(1L, new ApprenticeshipSearchQuery());
 
@@ -68,6 +68,9 @@ namespace SFA.DAS.Commitments.Api.UnitTests.Orchestrators.Employer
         {
             _mockMediator.Setup(m => m.SendAsync(It.IsAny<GetApprenticeshipsRequest>()))
                 .ReturnsAsync(new GetApprenticeshipsResponse { Data = new List<Apprenticeship>() });
+            _mockApprenticeshipFilter.Setup(m =>
+                m.Filter(It.IsAny<IList<Apprenticeship>>(), It.IsAny<ApprenticeshipSearchQuery>(), Originator.Employer))
+                .Returns<IList<Apprenticeship>, ApprenticeshipSearchQuery, Originator>((aps, q, o) => new FilterResult(aps.ToList(), 1, 25));
 
             var result = await _orchestrator.GetApprenticeships(1L, new ApprenticeshipSearchQuery());
 

--- a/src/SFA.DAS.Commitments.Api.UnitTests/Orchestrators/Employer/WhenGettingApprenticeshipSearch.cs
+++ b/src/SFA.DAS.Commitments.Api.UnitTests/Orchestrators/Employer/WhenGettingApprenticeshipSearch.cs
@@ -56,7 +56,7 @@ namespace SFA.DAS.Commitments.Api.UnitTests.Orchestrators.Employer
             // Return same IList<Apprenticeship> as input.
             _mockApprenticeshipFilter.Setup(m => 
                 m.Filter(It.IsAny<IList<Apprenticeship>>(), It.IsAny<ApprenticeshipSearchQuery>(), Originator.Employer))
-                .Returns<IList<Apprenticeship>, ApprenticeshipSearchQuery,Originator>((aps, q, o) => new FilterResult(aps.ToList(), 1, 25));
+                .Returns<IList<Apprenticeship>, ApprenticeshipSearchQuery,Originator>((aps, q, o) => new FilterResult(100, aps.ToList(), 1, 25));
 
             var result = await _orchestrator.GetApprenticeships(1L, new ApprenticeshipSearchQuery());
 
@@ -70,7 +70,7 @@ namespace SFA.DAS.Commitments.Api.UnitTests.Orchestrators.Employer
                 .ReturnsAsync(new GetApprenticeshipsResponse { Data = new List<Apprenticeship>() });
             _mockApprenticeshipFilter.Setup(m =>
                 m.Filter(It.IsAny<IList<Apprenticeship>>(), It.IsAny<ApprenticeshipSearchQuery>(), Originator.Employer))
-                .Returns<IList<Apprenticeship>, ApprenticeshipSearchQuery, Originator>((aps, q, o) => new FilterResult(aps.ToList(), 1, 25));
+                .Returns<IList<Apprenticeship>, ApprenticeshipSearchQuery, Originator>((aps, q, o) => new FilterResult(100, aps.ToList(), 1, 25));
 
             var result = await _orchestrator.GetApprenticeships(1L, new ApprenticeshipSearchQuery());
 

--- a/src/SFA.DAS.Commitments.Api.UnitTests/Orchestrators/Provider/WhenGettingApprenticeshipSearch.cs
+++ b/src/SFA.DAS.Commitments.Api.UnitTests/Orchestrators/Provider/WhenGettingApprenticeshipSearch.cs
@@ -37,27 +37,26 @@ namespace SFA.DAS.Commitments.Api.UnitTests.Orchestrators.Provider
                 Mock.Of<ICommitmentsLogger>(),
                 _mockFacetMapper.Object,
                 _mockApprenticeshipFilter.Object);
+
+            _mockMediator.Setup(m => m.SendAsync(It.IsAny<GetApprenticeshipsRequest>()))
+                .ReturnsAsync(new GetApprenticeshipsResponse
+                {
+                    Data = new List<Apprenticeship>
+                                                 {
+                                                                 new Apprenticeship { PaymentStatus = PaymentStatus.Active },
+                                                                 new Apprenticeship { PaymentStatus = PaymentStatus.PendingApproval },
+                                                                 new Apprenticeship { PaymentStatus = PaymentStatus.Paused }
+                                                 }
+                });
+
+            _mockApprenticeshipFilter.Setup(m =>
+               m.Filter(It.IsAny<IList<Apprenticeship>>(), It.IsAny<ApprenticeshipSearchQuery>(), Originator.Provider))
+               .Returns<IList<Apprenticeship>, ApprenticeshipSearchQuery, Originator>((aps, q, o) => new FilterResult(aps.ToList(), 1, 25));
         }
 
         [Test]
         public async Task ShouldFilterListFromNotApproved()
         {
-            _mockMediator.Setup(m => m.SendAsync(It.IsAny<GetApprenticeshipsRequest>()))
-                .ReturnsAsync(new GetApprenticeshipsResponse
-                                  {
-                                      Data = new List<Apprenticeship>
-                                                 {
-                                                     new Apprenticeship { PaymentStatus = PaymentStatus.Active },
-                                                     new Apprenticeship { PaymentStatus = PaymentStatus.PendingApproval },
-                                                     new Apprenticeship { PaymentStatus = PaymentStatus.Paused }
-                                                 }
-                                  });
-
-            // Return same IList<Apprenticeship> as input.
-            _mockApprenticeshipFilter.Setup(m => 
-                m.Filter(It.IsAny<IList<Apprenticeship>>(), It.IsAny<ApprenticeshipSearchQuery>(), Originator.Provider))
-                .Returns<IList<Apprenticeship>, ApprenticeshipSearchQuery,Originator>((aps, q, o) => aps);
-
             var result = await _orchestrator.GetApprenticeships(1L, new ApprenticeshipSearchQuery());
 
             result.Apprenticeships.Count().Should().Be(2);
@@ -67,7 +66,10 @@ namespace SFA.DAS.Commitments.Api.UnitTests.Orchestrators.Provider
         public async Task ShouldCallGetFacetAndMapper()
         {
             _mockMediator.Setup(m => m.SendAsync(It.IsAny<GetApprenticeshipsRequest>()))
-                .ReturnsAsync(new GetApprenticeshipsResponse { Data = new List<Apprenticeship>() });
+                .ReturnsAsync(new GetApprenticeshipsResponse
+                {
+                    Data = new List<Apprenticeship>()
+                });
 
             var result = await _orchestrator.GetApprenticeships(1L, new ApprenticeshipSearchQuery());
 
@@ -76,61 +78,6 @@ namespace SFA.DAS.Commitments.Api.UnitTests.Orchestrators.Provider
             _mockApprenticeshipFilter.Verify(m => m.Filter(It.IsAny<IList<Apprenticeship>>(), It.IsAny<ApprenticeshipSearchQuery>(), Originator.Provider), Times.Once);
 
             result.Apprenticeships.Count().Should().Be(0);
-        }
-
-        [TestCase(1, 100, 10, 1, Description = "Returns first page number if first page number passed in")]
-        [TestCase(14, 100, 10, 1, Description = "Returns first page number if page is not within range of total pages")]
-        [TestCase(10, 100, 10, 10, Description = "Returns page number if page is not within range of total pages")]
-        [TestCase(0, 100, 10, 1, Description = "Returns first page if page is not set (0)")]
-        public async Task ShouldReturnThePageNumber(int requestedPageNumber, int totalApprenticeships, int requestedPageSize, int expectedPageNumber)
-        {
-            var apprenticeships = CreateApprenticeships(totalApprenticeships);
-
-            _mockMediator.Setup(m => m.SendAsync(It.IsAny<GetApprenticeshipsRequest>()))
-                .ReturnsAsync(new GetApprenticeshipsResponse { Data = apprenticeships });
-
-            var result = await _orchestrator.GetApprenticeships(1L, new ApprenticeshipSearchQuery { PageNumber = requestedPageNumber, PageSize = requestedPageSize });
-
-            result.PageNumber.Should().Be(expectedPageNumber);
-        }
-
-        [TestCase(5, 5, Description = "Returns page size from query if > 0")]
-        [TestCase(0, 25, Description = "Defaults page size to 25 if the page size is not set (0)")]
-        public async Task ShouldReturnThePageSize(int requestedPageSize, int expectedPageSize)
-        {
-            var apprenticeships = CreateApprenticeships(20);
-
-            _mockMediator.Setup(m => m.SendAsync(It.IsAny<GetApprenticeshipsRequest>()))
-                .ReturnsAsync(new GetApprenticeshipsResponse { Data = apprenticeships });
-
-            var result = await _orchestrator.GetApprenticeships(1L, new ApprenticeshipSearchQuery { PageNumber = 1, PageSize = requestedPageSize });
-
-            result.PageSize.Should().Be(expectedPageSize);
-        }
-
-        [Test]
-        public async Task ShouldDefaultPagingValuesIfNotSet()
-        {
-            var apprenticeships = CreateApprenticeships(20);
-
-            _mockMediator.Setup(m => m.SendAsync(It.Is<GetApprenticeshipsRequest>(x => x.PageNumber == 1 && x.PageSize == 25)))
-                .ReturnsAsync(new GetApprenticeshipsResponse { Data = apprenticeships });
-
-            var result = await _orchestrator.GetApprenticeships(1L, new ApprenticeshipSearchQuery { PageNumber = 0, PageSize = 0 });
-
-            _mockMediator.Verify();
-        }
-
-        private static List<Apprenticeship> CreateApprenticeships(int totalApprenticeships)
-        {
-            var apprenticeships = new List<Apprenticeship>(totalApprenticeships);
-
-            for (int i = 0; i < totalApprenticeships - 1; i++)
-            {
-                apprenticeships.Add(new Apprenticeship { PaymentStatus = PaymentStatus.Active });
-            }
-
-            return apprenticeships;
         }
     }
 }

--- a/src/SFA.DAS.Commitments.Api.UnitTests/Orchestrators/Provider/WhenGettingApprenticeshipSearch.cs
+++ b/src/SFA.DAS.Commitments.Api.UnitTests/Orchestrators/Provider/WhenGettingApprenticeshipSearch.cs
@@ -51,7 +51,7 @@ namespace SFA.DAS.Commitments.Api.UnitTests.Orchestrators.Provider
 
             _mockApprenticeshipFilter.Setup(m =>
                m.Filter(It.IsAny<IList<Apprenticeship>>(), It.IsAny<ApprenticeshipSearchQuery>(), Originator.Provider))
-               .Returns<IList<Apprenticeship>, ApprenticeshipSearchQuery, Originator>((aps, q, o) => new FilterResult(aps.ToList(), 1, 25));
+               .Returns<IList<Apprenticeship>, ApprenticeshipSearchQuery, Originator>((aps, q, o) => new FilterResult(100, aps.ToList(), 1, 25));
         }
 
         [Test]

--- a/src/SFA.DAS.Commitments.Api.UnitTests/SFA.DAS.Commitments.Api.UnitTests.csproj
+++ b/src/SFA.DAS.Commitments.Api.UnitTests/SFA.DAS.Commitments.Api.UnitTests.csproj
@@ -71,9 +71,8 @@
       <HintPath>..\packages\AutoFixture.NUnit3.3.50.1\lib\net40\Ploeh.AutoFixture.NUnit3.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SFA.DAS.Commitments.Api.Types, Version=1.66.0.33236, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Commitments.Api.Types.1.66.0.33236\lib\net45\SFA.DAS.Commitments.Api.Types.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SFA.DAS.Commitments.Api.Types, Version=1.67.0.34274, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Commitments.Api.Types.1.67.0.34274\lib\net45\SFA.DAS.Commitments.Api.Types.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Net.Http" />

--- a/src/SFA.DAS.Commitments.Api.UnitTests/packages.config
+++ b/src/SFA.DAS.Commitments.Api.UnitTests/packages.config
@@ -11,5 +11,5 @@
   <package id="Moq" version="4.5.21" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NUnit" version="3.4.1" targetFramework="net45" />
-  <package id="SFA.DAS.Commitments.Api.Types" version="1.66.0.33236" targetFramework="net45" />
+  <package id="SFA.DAS.Commitments.Api.Types" version="1.67.0.34274" targetFramework="net45" />
 </packages>

--- a/src/SFA.DAS.Commitments.Api/Controllers/ProviderController.cs
+++ b/src/SFA.DAS.Commitments.Api/Controllers/ProviderController.cs
@@ -3,11 +3,9 @@ using System.Net;
 using System.Threading.Tasks;
 using System.Web.Http;
 
-using SFA.DAS.Commitments.Api.Models;
 using SFA.DAS.Commitments.Api.Orchestrators;
 using SFA.DAS.Commitments.Api.Types;
 using SFA.DAS.Commitments.Api.Types.Apprenticeship;
-using SFA.DAS.Commitments.Api.Types.Commitment;
 
 namespace SFA.DAS.Commitments.Api.Controllers
 {

--- a/src/SFA.DAS.Commitments.Api/Orchestrators/EmployerOrchestrator.cs
+++ b/src/SFA.DAS.Commitments.Api/Orchestrators/EmployerOrchestrator.cs
@@ -139,7 +139,7 @@ namespace SFA.DAS.Commitments.Api.Orchestrators
 
         public async Task<Apprenticeship.ApprenticeshipSearchResponse> GetApprenticeships(long accountId, Apprenticeship.ApprenticeshipSearchQuery query)
         {
-            _logger.Trace($"Getting apprenticeships with filtered query for employer account {accountId}", accountId: accountId);
+            _logger.Trace($"Getting apprenticeships with filter query for employer {accountId}. Page: {query.PageNumber}, PageSize: {query.PageSize}", accountId: accountId);
 
             var response = await _mediator.SendAsync(new GetApprenticeshipsRequest
             {
@@ -150,11 +150,14 @@ namespace SFA.DAS.Commitments.Api.Orchestrators
                 }
             });
 
-            var approvedApprenticeships = response.Data.Where(m => m.PaymentStatus != PaymentStatus.PendingApproval).ToList();
+            var approvedApprenticeships = response.Data
+                .Where(m => m.PaymentStatus != PaymentStatus.PendingApproval).ToList();
 
             var facets = _facetMapper.BuildFacets(approvedApprenticeships , query, Originator.Employer);
 
             var filteredApprenticeships = _apprenticeshipFilterService.Filter(approvedApprenticeships, query, Originator.Employer);
+
+            _logger.Info($"Retrieved {approvedApprenticeships.Count} apprenticeships with filter query for employer {accountId}. Page: {query.PageNumber}, PageSize: {query.PageSize}", accountId: accountId);
 
             return new Apprenticeship.ApprenticeshipSearchResponse
             {

--- a/src/SFA.DAS.Commitments.Api/Orchestrators/EmployerOrchestrator.cs
+++ b/src/SFA.DAS.Commitments.Api/Orchestrators/EmployerOrchestrator.cs
@@ -161,7 +161,7 @@ namespace SFA.DAS.Commitments.Api.Orchestrators
 
             return new Apprenticeship.ApprenticeshipSearchResponse
             {
-                Apprenticeships = filteredApprenticeships.Results,
+                Apprenticeships = filteredApprenticeships.PageOfResults,
                 Facets = facets,
                 TotalApprenticeships = approvedApprenticeships.Count,
                 PageNumber = filteredApprenticeships.PageNumber,

--- a/src/SFA.DAS.Commitments.Api/Orchestrators/EmployerOrchestrator.cs
+++ b/src/SFA.DAS.Commitments.Api/Orchestrators/EmployerOrchestrator.cs
@@ -157,10 +157,12 @@ namespace SFA.DAS.Commitments.Api.Orchestrators
             var filteredProviders = _apprenticeshipFilterService.Filter(approvedApprenticeships, query, Originator.Employer);
 
             return new Apprenticeship.ApprenticeshipSearchResponse
-                       {
-                           Apprenticeships = filteredProviders,
-                           Facets = facets,
-                           TotalApprenticeships = approvedApprenticeships.Count
+            {
+                Apprenticeships = filteredProviders,
+                Facets = facets,
+                TotalApprenticeships = approvedApprenticeships.Count,
+                PageNumber = query.PageNumber,
+                PageSize = query.PageSize
             };
         }
 

--- a/src/SFA.DAS.Commitments.Api/Orchestrators/EmployerOrchestrator.cs
+++ b/src/SFA.DAS.Commitments.Api/Orchestrators/EmployerOrchestrator.cs
@@ -154,15 +154,15 @@ namespace SFA.DAS.Commitments.Api.Orchestrators
 
             var facets = _facetMapper.BuildFacets(approvedApprenticeships , query, Originator.Employer);
 
-            var filteredProviders = _apprenticeshipFilterService.Filter(approvedApprenticeships, query, Originator.Employer);
+            var filteredApprenticeships = _apprenticeshipFilterService.Filter(approvedApprenticeships, query, Originator.Employer);
 
             return new Apprenticeship.ApprenticeshipSearchResponse
             {
-                Apprenticeships = filteredProviders,
+                Apprenticeships = filteredApprenticeships.Results,
                 Facets = facets,
                 TotalApprenticeships = approvedApprenticeships.Count,
-                PageNumber = query.PageNumber,
-                PageSize = query.PageSize
+                PageNumber = filteredApprenticeships.PageNumber,
+                PageSize = filteredApprenticeships.PageSize
             };
         }
 

--- a/src/SFA.DAS.Commitments.Api/Orchestrators/ProviderOrchestrator.cs
+++ b/src/SFA.DAS.Commitments.Api/Orchestrators/ProviderOrchestrator.cs
@@ -131,9 +131,7 @@ namespace SFA.DAS.Commitments.Api.Orchestrators
                 {
                     CallerType = CallerType.Provider,
                     Id = providerId,
-                },
-                PageNumber = query.PageNumber == 0 ? GetApprenticeshipsRequest.DefaultPageNumber : query.PageNumber,
-                PageSize = query.PageSize == 0 ? GetApprenticeshipsRequest.DefaultPageSize : query.PageSize
+                }
             };
 
             var response = await _mediator.SendAsync(request);
@@ -147,11 +145,11 @@ namespace SFA.DAS.Commitments.Api.Orchestrators
 
             return new ApprenticeshipSearchResponse
             {
-                Apprenticeships = filteredApprenticeships,
+                Apprenticeships = filteredApprenticeships.Results,
                 Facets = facets,
                 TotalApprenticeships = approvedApprenticeships.Count,
-                PageNumber = DeterminePageNumberBasedOnTotalHits(request, approvedApprenticeships),
-                PageSize = request.PageSize
+                PageNumber = filteredApprenticeships.PageNumber,
+                PageSize = filteredApprenticeships.PageSize
             };
         }
 
@@ -435,14 +433,6 @@ namespace SFA.DAS.Commitments.Api.Orchestrators
             var result = await _mediator.SendAsync(new GetBulkUploadFileQuery { ProviderId = providerId, BulkUploadFileId = bulkUploadFileId });
 
             return result.Data;
-        }
-
-        private static int DeterminePageNumberBasedOnTotalHits(GetApprenticeshipsRequest request, List<Types.Apprenticeship.Apprenticeship> approvedApprenticeships)
-        {
-            if (request.PageNumber == 0 || request.PageNumber > (approvedApprenticeships.Count + request.PageSize - 1) / request.PageSize)
-                return 1;
-
-            return request.PageNumber;
         }
     }
 }

--- a/src/SFA.DAS.Commitments.Api/Orchestrators/ProviderOrchestrator.cs
+++ b/src/SFA.DAS.Commitments.Api/Orchestrators/ProviderOrchestrator.cs
@@ -143,11 +143,11 @@ namespace SFA.DAS.Commitments.Api.Orchestrators
 
             var facets = _facetMapper.BuildFacets(approvedApprenticeships, query, Originator.Provider);
 
-            var filteredProviders = _apprenticeshipFilterService.Filter(approvedApprenticeships, query, Originator.Provider);
+            var filteredApprenticeships = _apprenticeshipFilterService.Filter(approvedApprenticeships, query, Originator.Provider);
 
             return new ApprenticeshipSearchResponse
             {
-                Apprenticeships = filteredProviders,
+                Apprenticeships = filteredApprenticeships,
                 Facets = facets,
                 TotalApprenticeships = approvedApprenticeships.Count,
                 PageNumber = DeterminePageNumberBasedOnTotalHits(request, approvedApprenticeships),

--- a/src/SFA.DAS.Commitments.Api/Orchestrators/ProviderOrchestrator.cs
+++ b/src/SFA.DAS.Commitments.Api/Orchestrators/ProviderOrchestrator.cs
@@ -144,9 +144,9 @@ namespace SFA.DAS.Commitments.Api.Orchestrators
 
             return new ApprenticeshipSearchResponse
             {
-                Apprenticeships = filteredApprenticeships.Results,
+                Apprenticeships = filteredApprenticeships.PageOfResults,
                 Facets = facets,
-                TotalApprenticeships = approvedApprenticeships.Count,
+                TotalApprenticeships = filteredApprenticeships.TotalResults,
                 PageNumber = filteredApprenticeships.PageNumber,
                 PageSize = filteredApprenticeships.PageSize
             };

--- a/src/SFA.DAS.Commitments.Api/SFA.DAS.Commitments.Api.csproj
+++ b/src/SFA.DAS.Commitments.Api/SFA.DAS.Commitments.Api.csproj
@@ -150,9 +150,8 @@
     <Reference Include="Polly, Version=5.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Polly.5.1.0\lib\net45\Polly.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.Commitments.Api.Types, Version=1.66.0.33236, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Commitments.Api.Types.1.66.0.33236\lib\net45\SFA.DAS.Commitments.Api.Types.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SFA.DAS.Commitments.Api.Types, Version=1.67.0.34274, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Commitments.Api.Types.1.67.0.34274\lib\net45\SFA.DAS.Commitments.Api.Types.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.Configuration, Version=1.0.0.6634, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Configuration.1.0.0.6634\lib\net45\SFA.DAS.Configuration.dll</HintPath>

--- a/src/SFA.DAS.Commitments.Api/packages.config
+++ b/src/SFA.DAS.Commitments.Api/packages.config
@@ -43,7 +43,7 @@
   <package id="NUnit.Extension.VSProjectLoader" version="3.4.0" targetFramework="net45" />
   <package id="Polly" version="5.1.0" targetFramework="net45" />
   <package id="SFA.DAS.ApiTokens.Client" version="1.3.0.12902" targetFramework="net45" />
-  <package id="SFA.DAS.Commitments.Api.Types" version="1.66.0.33236" targetFramework="net45" />
+  <package id="SFA.DAS.Commitments.Api.Types" version="1.67.0.34274" targetFramework="net45" />
   <package id="SFA.DAS.Configuration" version="1.0.0.6634" targetFramework="net45" />
   <package id="SFA.DAS.Configuration.AzureTableStorage" version="1.0.0.6634" targetFramework="net45" />
   <package id="SFA.DAS.Configuration.FileStorage" version="1.0.0.6634" targetFramework="net45" />

--- a/src/SFA.DAS.Commitments.Application.UnitTests/SFA.DAS.Commitments.Application.UnitTests.csproj
+++ b/src/SFA.DAS.Commitments.Application.UnitTests/SFA.DAS.Commitments.Application.UnitTests.csproj
@@ -167,11 +167,12 @@
     <Compile Include="Rules\ApprenticeshipUpdateRules\WhenDetermineNewAgreementStatus.cs" />
     <Compile Include="Rules\ApprenticeshipUpdateRules\WhenDetermineWhetherChangeRequireAgreement.cs" />
     <Compile Include="Rules\CommitmentRules\WhenDetermineAgreementStatus.cs" />
+    <Compile Include="Service\ApprenticeshipFilterService\WhenPagingFilterResults.cs" />
     <Compile Include="Service\Facets\WhenExtractingApprenticeshipStatuses.cs" />
     <Compile Include="Service\Facets\WhenExtractingProviders.cs" />
     <Compile Include="Service\Facets\WhenExtractingRecordStatuses.cs" />
     <Compile Include="Service\Facets\WhenExtractingTrainingCourse.cs" />
-    <Compile Include="Service\WhenFilterApprenticeships.cs" />
+    <Compile Include="Service\ApprenticeshipFilterService\WhenFilterApprenticeships.cs" />
     <Compile Include="StubCurrentDateTime.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SFA.DAS.Commitments.Application.UnitTests/SFA.DAS.Commitments.Application.UnitTests.csproj
+++ b/src/SFA.DAS.Commitments.Application.UnitTests/SFA.DAS.Commitments.Application.UnitTests.csproj
@@ -72,9 +72,8 @@
       <HintPath>..\packages\AutoFixture.NUnit3.3.50.1\lib\net40\Ploeh.AutoFixture.NUnit3.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SFA.DAS.Commitments.Api.Types, Version=1.66.0.33236, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Commitments.Api.Types.1.66.0.33236\lib\net45\SFA.DAS.Commitments.Api.Types.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SFA.DAS.Commitments.Api.Types, Version=1.67.0.34274, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Commitments.Api.Types.1.67.0.34274\lib\net45\SFA.DAS.Commitments.Api.Types.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.Events.Api.Client, Version=1.26.0.33437, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Events.Api.Client.1.26.0.33437\lib\net45\SFA.DAS.Events.Api.Client.dll</HintPath>

--- a/src/SFA.DAS.Commitments.Application.UnitTests/Service/ApprenticeshipFilterService/WhenFilterApprenticeships.cs
+++ b/src/SFA.DAS.Commitments.Application.UnitTests/Service/ApprenticeshipFilterService/WhenFilterApprenticeships.cs
@@ -7,10 +7,11 @@ using NUnit.Framework;
 
 using SFA.DAS.Commitments.Api.Types.Apprenticeship;
 using SFA.DAS.Commitments.Api.Types.Apprenticeship.Types;
-using SFA.DAS.Commitments.Application.Services;
 
-namespace SFA.DAS.Commitments.Application.UnitTests.Service
+namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilterService
 {
+    using SFA.DAS.Commitments.Application.Services;
+
     [TestFixture]
     public class WhenFilterApprenticeships
     {
@@ -389,110 +390,6 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service
             var result = _sut.Filter(_apprenticeships, query, Originator.Provider);
 
             result.Results.Count.Should().Be(_apprenticeships.Count);
-        }
-
-        [Test]
-        public void ShouldReturnFirstPageOfApprenticeships()
-        {
-            const int RequestedPageNumber = 1;
-            const int RequestedPageSize = 4;
-
-            var apprenticeships = CreatePaginiationApprenticeships(20);
-            var query = new ApprenticeshipSearchQuery { PageNumber = RequestedPageNumber, PageSize = RequestedPageSize };
-
-            var result = _sut.Filter(apprenticeships, query, Originator.Provider);
-
-            result.Results.Count.Should().Be(RequestedPageSize);
-            result.Results.Select(x => x.Id).ShouldAllBeEquivalentTo(new List<int> { 1, 2, 3, 4 });
-        }
-
-        [Test]
-        public void ShouldReturnSecondPageOfApprenticeships()
-        {
-            const int RequestedPageNumber = 2;
-            const int RequestedPageSize = 4;
-
-            var apprenticeships = CreatePaginiationApprenticeships(20);
-            var query = new ApprenticeshipSearchQuery { PageNumber = RequestedPageNumber, PageSize = RequestedPageSize };
-
-            var result = _sut.Filter(apprenticeships, query, Originator.Provider);
-
-            result.Results.Count.Should().Be(RequestedPageSize);
-            result.Results.Select(x => x.Id).ShouldAllBeEquivalentTo(new List<int> { 5, 6, 7, 8 });
-        }
-
-        [Test]
-        public void ShouldReturnFullPageForLastPage()
-        {
-            const int RequestedPageNumber = 5;
-            const int RequestedPageSize = 4;
-
-            var apprenticeships = CreatePaginiationApprenticeships(20);
-            var query = new ApprenticeshipSearchQuery { PageNumber = RequestedPageNumber, PageSize = RequestedPageSize };
-
-            var result = _sut.Filter(apprenticeships, query, Originator.Provider);
-
-            result.Results.Count.Should().Be(RequestedPageSize);
-            result.Results.Select(x => x.Id).ShouldAllBeEquivalentTo(new List<int> { 17, 18, 19, 20 });
-        }
-
-        [Test]
-        public void ShouldReturnPartialPageForLastPage()
-        {
-            const int RequestedPageNumber = 5;
-            const int RequestedPageSize = 4;
-
-            var apprenticeships = CreatePaginiationApprenticeships(18);
-            var query = new ApprenticeshipSearchQuery { PageNumber = RequestedPageNumber, PageSize = RequestedPageSize };
-
-            var result = _sut.Filter(apprenticeships, query, Originator.Provider);
-
-            result.Results.Count.Should().Be(RequestedPageSize - 2);
-            result.Results.Select(x => x.Id).ShouldAllBeEquivalentTo(new List<int> { 17, 18 });
-        }
-
-        [TestCase(1, 100, 10, 1, Description = "Returns first page number if first page number passed in")]
-        [TestCase(14, 100, 10, 10, Description = "Returns last page number if page is not within range of total pages")]
-        [TestCase(10, 100, 10, 10, Description = "Returns page number if page is not within range of total pages")]
-        [TestCase(0, 100, 10, 1, Description = "Returns first page if page is not set (0)")]
-        public void ShouldReturnThePageNumber(int requestedPageNumber, int totalApprenticeships, int requestedPageSize, int expectedPageNumber)
-        {
-            var apprenticeships = CreatePaginiationApprenticeships(totalApprenticeships);
-
-            var query = new ApprenticeshipSearchQuery { PageNumber = requestedPageNumber, PageSize = requestedPageSize };
-
-            var result = _sut.Filter(apprenticeships, query, Originator.Provider);
-
-            result.PageNumber.Should().Be(expectedPageNumber);
-        }
-
-        [TestCase(5, 5, Description = "Returns page size from query if > 0")]
-        [TestCase(0, 25, Description = "Defaults page size to 25 if the page size is not set (0)")]
-        public void ShouldReturnThePageSize(int requestedPageSize, int expectedPageSize)
-        {
-            var apprenticeships = CreatePaginiationApprenticeships(20);
-
-            var query = new ApprenticeshipSearchQuery { PageNumber = 1, PageSize = requestedPageSize };
-
-            var result = _sut.Filter(apprenticeships, query, Originator.Provider);
-
-            result.PageSize.Should().Be(expectedPageSize);
-        }
-
-        private static IList<Apprenticeship> CreatePaginiationApprenticeships(int count)
-        {
-            var apprenticeships = new List<Apprenticeship>(count);
-
-            for (int i = 1; i <= count; i++)
-            {
-                apprenticeships.Add(new Apprenticeship
-                {
-                    Id = i,
-                    PaymentStatus = PaymentStatus.Active
-                });
-            }
-
-            return apprenticeships;
         }
     }
 }

--- a/src/SFA.DAS.Commitments.Application.UnitTests/Service/ApprenticeshipFilterService/WhenFilterApprenticeships.cs
+++ b/src/SFA.DAS.Commitments.Application.UnitTests/Service/ApprenticeshipFilterService/WhenFilterApprenticeships.cs
@@ -51,7 +51,7 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
 
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Results.Count.Should().Be(2);
+            result.PageOfResults.Count.Should().Be(2);
         }
 
         [TestCase(Originator.Provider)]
@@ -66,8 +66,8 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
                             };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Results.Count.Should().Be(1);
-            result.Results.Single().FirstName.Should().Be("Live");
+            result.PageOfResults.Count.Should().Be(1);
+            result.PageOfResults.Single().FirstName.Should().Be("Live");
         }
 
         [TestCase(Originator.Provider)]
@@ -88,8 +88,8 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
                             };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Results.Count.Should().Be(1);
-            result.Results.Single().FirstName.Should().Be("Live");
+            result.PageOfResults.Count.Should().Be(1);
+            result.PageOfResults.Single().FirstName.Should().Be("Live");
         }
 
         [TestCase(Originator.Provider)]
@@ -102,7 +102,7 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
             };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Results.Count.Should().Be(1);
+            result.PageOfResults.Count.Should().Be(1);
         }
 
         [TestCase(Originator.Provider)]
@@ -115,7 +115,7 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
             };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Results.Count.Should().Be(1);
+            result.PageOfResults.Count.Should().Be(1);
         }
 
         [TestCase(Originator.Provider)]
@@ -129,8 +129,8 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
             };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Results.Count.Should().Be(1);
-            result.Results.FirstOrDefault().FirstName.Should().Be("ILR Data Mismatch");
+            result.PageOfResults.Count.Should().Be(1);
+            result.PageOfResults.FirstOrDefault().FirstName.Should().Be("ILR Data Mismatch");
         }
 
         [TestCase(Originator.Provider)]
@@ -145,9 +145,9 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
             };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Results.Count.Should().Be(2);
-            result.Results.Count(m => m.FirstName == "ILR Data Mismatch").Should().Be(1);
-            result.Results.Count(m => m.FirstName == "WaitingToStart").Should().Be(1);
+            result.PageOfResults.Count.Should().Be(2);
+            result.PageOfResults.Count(m => m.FirstName == "ILR Data Mismatch").Should().Be(1);
+            result.PageOfResults.Count(m => m.FirstName == "WaitingToStart").Should().Be(1);
         }
 
         [TestCase(Originator.Provider)]
@@ -162,9 +162,9 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
             };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Results.Count.Should().Be(2);
-            result.Results.Count(m => m.FirstName == "ILR Data Mismatch").Should().Be(1);
-            result.Results.Count(m => m.FirstName == "WaitingToStart").Should().Be(1);
+            result.PageOfResults.Count.Should().Be(2);
+            result.PageOfResults.Count(m => m.FirstName == "ILR Data Mismatch").Should().Be(1);
+            result.PageOfResults.Count(m => m.FirstName == "WaitingToStart").Should().Be(1);
         }
 
 
@@ -175,7 +175,7 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
             var query = new ApprenticeshipSearchQuery { RecordStatuses = new List<RecordStatus>(new [] { RecordStatus.ChangesPending, } ) };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Results.Count.Should().Be(0);
+            result.PageOfResults.Count.Should().Be(0);
         }
 
         [TestCase(Originator.Provider)]
@@ -192,8 +192,8 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
             var query = new ApprenticeshipSearchQuery { RecordStatuses = new List<RecordStatus>(new[] { RecordStatus.ChangesPending, }) };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Results.Count.Should().Be(1);
-            result.Results.Single().FirstName.Should().Be("ChangesPending");
+            result.PageOfResults.Count.Should().Be(1);
+            result.PageOfResults.Single().FirstName.Should().Be("ChangesPending");
         }
 
         [TestCase(Originator.Provider, Originator.Employer)]
@@ -210,8 +210,8 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
             var query = new ApprenticeshipSearchQuery { RecordStatuses = new List<RecordStatus>(new[] { RecordStatus.ChangesForReview, }) };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Results.Count.Should().Be(1);
-            result.Results.Single().FirstName.Should().Be("ChangesForReview");
+            result.PageOfResults.Count.Should().Be(1);
+            result.PageOfResults.Single().FirstName.Should().Be("ChangesForReview");
         }
 
         [TestCase(Originator.Provider)]
@@ -237,8 +237,8 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
             var query = new ApprenticeshipSearchQuery { TrainingCourses = new List<string>(new [] { "123-00-009", "35", "2" } )};
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Results.Count.Should().Be(1);
-            result.Results.Single().Id.Should().Be(009);
+            result.PageOfResults.Count.Should().Be(1);
+            result.PageOfResults.Single().Id.Should().Be(009);
         }
 
         [TestCase(Originator.Provider)]
@@ -264,7 +264,7 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
             var query = new ApprenticeshipSearchQuery { TrainingCourses = new List<string>(new[] { "123-00-009", "35", "2" }) };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Results.Count.Should().Be(0);
+            result.PageOfResults.Count.Should().Be(0);
         }
 
 
@@ -295,8 +295,8 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
             var query = new ApprenticeshipSearchQuery { EmployerOrganisationIds = new List<string> { "09990" } };
             var result = _sut.Filter(_apprenticeships, query, Originator.Provider);
 
-            result.Results.Count.Should().Be(1);
-            result.Results.FirstOrDefault().LegalEntityName.Should().Be("Employer 999");
+            result.PageOfResults.Count.Should().Be(1);
+            result.PageOfResults.FirstOrDefault().LegalEntityName.Should().Be("Employer 999");
         }
 
         [Test]
@@ -324,7 +324,7 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
             var query = new ApprenticeshipSearchQuery { EmployerOrganisationIds = new List<string> { "999" } };
             var result = _sut.Filter(_apprenticeships, query, Originator.Employer);
 
-            result.Results.Count.Should().Be(_apprenticeships.Count);
+            result.PageOfResults.Count.Should().Be(_apprenticeships.Count);
         }
 
         [Test]
@@ -356,8 +356,8 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
             var query = new ApprenticeshipSearchQuery { TrainingProviderIds = new List<long> { 007 } };
             var result = _sut.Filter(_apprenticeships, query, Originator.Employer);
 
-            result.Results.Count.Should().Be(1);
-            result.Results.FirstOrDefault().ProviderName.Should().Be("Provider 007");
+            result.PageOfResults.Count.Should().Be(1);
+            result.PageOfResults.FirstOrDefault().ProviderName.Should().Be("Provider 007");
         }
 
         [Test]
@@ -389,7 +389,7 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
             var query = new ApprenticeshipSearchQuery { TrainingProviderIds = new List<long> { 007 } };
             var result = _sut.Filter(_apprenticeships, query, Originator.Provider);
 
-            result.Results.Count.Should().Be(_apprenticeships.Count);
+            result.PageOfResults.Count.Should().Be(_apprenticeships.Count);
         }
     }
 }

--- a/src/SFA.DAS.Commitments.Application.UnitTests/Service/ApprenticeshipFilterService/WhenPagingFilterResults.cs
+++ b/src/SFA.DAS.Commitments.Application.UnitTests/Service/ApprenticeshipFilterService/WhenPagingFilterResults.cs
@@ -35,8 +35,8 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
 
             var result = _sut.Filter(apprenticeships, query, Originator.Provider);
 
-            result.Results.Count.Should().Be(RequestedPageSize);
-            result.Results.Select(x => x.Id).ShouldAllBeEquivalentTo(new List<int> { 1, 2, 3, 4 });
+            result.PageOfResults.Count.Should().Be(RequestedPageSize);
+            result.PageOfResults.Select(x => x.Id).ShouldAllBeEquivalentTo(new List<int> { 1, 2, 3, 4 });
         }
 
         [Test]
@@ -50,8 +50,8 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
 
             var result = _sut.Filter(apprenticeships, query, Originator.Provider);
 
-            result.Results.Count.Should().Be(RequestedPageSize);
-            result.Results.Select(x => x.Id).ShouldAllBeEquivalentTo(new List<int> { 5, 6, 7, 8 });
+            result.PageOfResults.Count.Should().Be(RequestedPageSize);
+            result.PageOfResults.Select(x => x.Id).ShouldAllBeEquivalentTo(new List<int> { 5, 6, 7, 8 });
         }
 
         [Test]
@@ -65,8 +65,8 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
 
             var result = _sut.Filter(apprenticeships, query, Originator.Provider);
 
-            result.Results.Count.Should().Be(RequestedPageSize);
-            result.Results.Select(x => x.Id).ShouldAllBeEquivalentTo(new List<int> { 17, 18, 19, 20 });
+            result.PageOfResults.Count.Should().Be(RequestedPageSize);
+            result.PageOfResults.Select(x => x.Id).ShouldAllBeEquivalentTo(new List<int> { 17, 18, 19, 20 });
         }
 
         [Test]
@@ -80,8 +80,8 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
 
             var result = _sut.Filter(apprenticeships, query, Originator.Provider);
 
-            result.Results.Count.Should().Be(RequestedPageSize - 2);
-            result.Results.Select(x => x.Id).ShouldAllBeEquivalentTo(new List<int> { 17, 18 });
+            result.PageOfResults.Count.Should().Be(RequestedPageSize - 2);
+            result.PageOfResults.Select(x => x.Id).ShouldAllBeEquivalentTo(new List<int> { 17, 18 });
         }
 
         [TestCase(1, 100, 10, 1, Description = "Returns first page number if first page number passed in")]

--- a/src/SFA.DAS.Commitments.Application.UnitTests/Service/ApprenticeshipFilterService/WhenPagingFilterResults.cs
+++ b/src/SFA.DAS.Commitments.Application.UnitTests/Service/ApprenticeshipFilterService/WhenPagingFilterResults.cs
@@ -88,6 +88,7 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
         [TestCase(14, 100, 10, 10, Description = "Returns last page number if page is not within range of total pages")]
         [TestCase(10, 100, 10, 10, Description = "Returns page number if page is not within range of total pages")]
         [TestCase(0, 100, 10, 1, Description = "Returns first page if page is not set (0)")]
+        [TestCase(-3, 100, 10, 1, Description = "Returns first page if page less than zero")]
         public void ShouldReturnThePageNumber(int requestedPageNumber, int totalApprenticeships, int requestedPageSize, int expectedPageNumber)
         {
             var apprenticeships = CreatePaginiationApprenticeships(totalApprenticeships);
@@ -101,6 +102,7 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilter
 
         [TestCase(5, 5, Description = "Returns page size from query if > 0")]
         [TestCase(0, 25, Description = "Defaults page size to 25 if the page size is not set (0)")]
+        [TestCase(-34, 25, Description = "Defaults page size to 25 if the page size is set to negative number")]
         public void ShouldReturnThePageSize(int requestedPageSize, int expectedPageSize)
         {
             var apprenticeships = CreatePaginiationApprenticeships(20);

--- a/src/SFA.DAS.Commitments.Application.UnitTests/Service/ApprenticeshipFilterService/WhenPagingFilterResults.cs
+++ b/src/SFA.DAS.Commitments.Application.UnitTests/Service/ApprenticeshipFilterService/WhenPagingFilterResults.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using FluentAssertions;
+using NUnit.Framework;
+
+using SFA.DAS.Commitments.Api.Types.Apprenticeship;
+using SFA.DAS.Commitments.Api.Types.Apprenticeship.Types;
+
+
+namespace SFA.DAS.Commitments.Application.UnitTests.Service.ApprenticeshipFilterService
+{
+    using SFA.DAS.Commitments.Application.Services;
+
+    [TestFixture]
+    public class WhenPagingFilterResults
+    {
+        private ApprenticeshipFilterService _sut;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _sut = new ApprenticeshipFilterService(new FacetMapper());
+        }
+
+        [Test]
+        public void ShouldReturnFirstPageOfApprenticeships()
+        {
+            const int RequestedPageNumber = 1;
+            const int RequestedPageSize = 4;
+
+            var apprenticeships = CreatePaginiationApprenticeships(20);
+            var query = new ApprenticeshipSearchQuery { PageNumber = RequestedPageNumber, PageSize = RequestedPageSize };
+
+            var result = _sut.Filter(apprenticeships, query, Originator.Provider);
+
+            result.Results.Count.Should().Be(RequestedPageSize);
+            result.Results.Select(x => x.Id).ShouldAllBeEquivalentTo(new List<int> { 1, 2, 3, 4 });
+        }
+
+        [Test]
+        public void ShouldReturnSecondPageOfApprenticeships()
+        {
+            const int RequestedPageNumber = 2;
+            const int RequestedPageSize = 4;
+
+            var apprenticeships = CreatePaginiationApprenticeships(20);
+            var query = new ApprenticeshipSearchQuery { PageNumber = RequestedPageNumber, PageSize = RequestedPageSize };
+
+            var result = _sut.Filter(apprenticeships, query, Originator.Provider);
+
+            result.Results.Count.Should().Be(RequestedPageSize);
+            result.Results.Select(x => x.Id).ShouldAllBeEquivalentTo(new List<int> { 5, 6, 7, 8 });
+        }
+
+        [Test]
+        public void ShouldReturnFullPageForLastPage()
+        {
+            const int RequestedPageNumber = 5;
+            const int RequestedPageSize = 4;
+
+            var apprenticeships = CreatePaginiationApprenticeships(20);
+            var query = new ApprenticeshipSearchQuery { PageNumber = RequestedPageNumber, PageSize = RequestedPageSize };
+
+            var result = _sut.Filter(apprenticeships, query, Originator.Provider);
+
+            result.Results.Count.Should().Be(RequestedPageSize);
+            result.Results.Select(x => x.Id).ShouldAllBeEquivalentTo(new List<int> { 17, 18, 19, 20 });
+        }
+
+        [Test]
+        public void ShouldReturnPartialPageForLastPage()
+        {
+            const int RequestedPageNumber = 5;
+            const int RequestedPageSize = 4;
+
+            var apprenticeships = CreatePaginiationApprenticeships(18);
+            var query = new ApprenticeshipSearchQuery { PageNumber = RequestedPageNumber, PageSize = RequestedPageSize };
+
+            var result = _sut.Filter(apprenticeships, query, Originator.Provider);
+
+            result.Results.Count.Should().Be(RequestedPageSize - 2);
+            result.Results.Select(x => x.Id).ShouldAllBeEquivalentTo(new List<int> { 17, 18 });
+        }
+
+        [TestCase(1, 100, 10, 1, Description = "Returns first page number if first page number passed in")]
+        [TestCase(14, 100, 10, 10, Description = "Returns last page number if page is not within range of total pages")]
+        [TestCase(10, 100, 10, 10, Description = "Returns page number if page is not within range of total pages")]
+        [TestCase(0, 100, 10, 1, Description = "Returns first page if page is not set (0)")]
+        public void ShouldReturnThePageNumber(int requestedPageNumber, int totalApprenticeships, int requestedPageSize, int expectedPageNumber)
+        {
+            var apprenticeships = CreatePaginiationApprenticeships(totalApprenticeships);
+
+            var query = new ApprenticeshipSearchQuery { PageNumber = requestedPageNumber, PageSize = requestedPageSize };
+
+            var result = _sut.Filter(apprenticeships, query, Originator.Provider);
+
+            result.PageNumber.Should().Be(expectedPageNumber);
+        }
+
+        [TestCase(5, 5, Description = "Returns page size from query if > 0")]
+        [TestCase(0, 25, Description = "Defaults page size to 25 if the page size is not set (0)")]
+        public void ShouldReturnThePageSize(int requestedPageSize, int expectedPageSize)
+        {
+            var apprenticeships = CreatePaginiationApprenticeships(20);
+
+            var query = new ApprenticeshipSearchQuery { PageNumber = 1, PageSize = requestedPageSize };
+
+            var result = _sut.Filter(apprenticeships, query, Originator.Provider);
+
+            result.PageSize.Should().Be(expectedPageSize);
+        }
+
+        private static IList<Apprenticeship> CreatePaginiationApprenticeships(int count)
+        {
+            var apprenticeships = new List<Apprenticeship>(count);
+
+            for (int i = 1; i <= count; i++)
+            {
+                apprenticeships.Add(new Apprenticeship
+                {
+                    Id = i,
+                    PaymentStatus = PaymentStatus.Active
+                });
+            }
+
+            return apprenticeships;
+        }
+    }
+}

--- a/src/SFA.DAS.Commitments.Application.UnitTests/Service/WhenFilterApprenticeships.cs
+++ b/src/SFA.DAS.Commitments.Application.UnitTests/Service/WhenFilterApprenticeships.cs
@@ -7,7 +7,6 @@ using NUnit.Framework;
 
 using SFA.DAS.Commitments.Api.Types.Apprenticeship;
 using SFA.DAS.Commitments.Api.Types.Apprenticeship.Types;
-using SFA.DAS.Commitments.Api.Types.DataLock.Types;
 using SFA.DAS.Commitments.Application.Services;
 
 namespace SFA.DAS.Commitments.Application.UnitTests.Service
@@ -51,7 +50,7 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service
 
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Count().Should().Be(2);
+            result.Results.Count.Should().Be(2);
         }
 
         [TestCase(Originator.Provider)]
@@ -66,8 +65,8 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service
                             };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Count().Should().Be(1);
-            result.Single().FirstName.Should().Be("Live");
+            result.Results.Count.Should().Be(1);
+            result.Results.Single().FirstName.Should().Be("Live");
         }
 
         [TestCase(Originator.Provider)]
@@ -88,8 +87,8 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service
                             };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Count().Should().Be(1);
-            result.Single().FirstName.Should().Be("Live");
+            result.Results.Count.Should().Be(1);
+            result.Results.Single().FirstName.Should().Be("Live");
         }
 
         [TestCase(Originator.Provider)]
@@ -102,7 +101,7 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service
             };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Count().Should().Be(1);
+            result.Results.Count.Should().Be(1);
         }
 
         [TestCase(Originator.Provider)]
@@ -115,7 +114,7 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service
             };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Count().Should().Be(1);
+            result.Results.Count.Should().Be(1);
         }
 
         [TestCase(Originator.Provider)]
@@ -129,8 +128,8 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service
             };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Count().Should().Be(1);
-            result.FirstOrDefault().FirstName.Should().Be("ILR Data Mismatch");
+            result.Results.Count.Should().Be(1);
+            result.Results.FirstOrDefault().FirstName.Should().Be("ILR Data Mismatch");
         }
 
         [TestCase(Originator.Provider)]
@@ -145,9 +144,9 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service
             };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Count().Should().Be(2);
-            result.Count(m => m.FirstName == "ILR Data Mismatch").Should().Be(1);
-            result.Count(m => m.FirstName == "WaitingToStart").Should().Be(1);
+            result.Results.Count.Should().Be(2);
+            result.Results.Count(m => m.FirstName == "ILR Data Mismatch").Should().Be(1);
+            result.Results.Count(m => m.FirstName == "WaitingToStart").Should().Be(1);
         }
 
         [TestCase(Originator.Provider)]
@@ -162,9 +161,9 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service
             };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Count().Should().Be(2);
-            result.Count(m => m.FirstName == "ILR Data Mismatch").Should().Be(1);
-            result.Count(m => m.FirstName == "WaitingToStart").Should().Be(1);
+            result.Results.Count.Should().Be(2);
+            result.Results.Count(m => m.FirstName == "ILR Data Mismatch").Should().Be(1);
+            result.Results.Count(m => m.FirstName == "WaitingToStart").Should().Be(1);
         }
 
 
@@ -175,7 +174,7 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service
             var query = new ApprenticeshipSearchQuery { RecordStatuses = new List<RecordStatus>(new [] { RecordStatus.ChangesPending, } ) };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Count().Should().Be(0);
+            result.Results.Count.Should().Be(0);
         }
 
         [TestCase(Originator.Provider)]
@@ -192,8 +191,8 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service
             var query = new ApprenticeshipSearchQuery { RecordStatuses = new List<RecordStatus>(new[] { RecordStatus.ChangesPending, }) };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Count().Should().Be(1);
-            result.Single().FirstName.Should().Be("ChangesPending");
+            result.Results.Count.Should().Be(1);
+            result.Results.Single().FirstName.Should().Be("ChangesPending");
         }
 
         [TestCase(Originator.Provider, Originator.Employer)]
@@ -210,8 +209,8 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service
             var query = new ApprenticeshipSearchQuery { RecordStatuses = new List<RecordStatus>(new[] { RecordStatus.ChangesForReview, }) };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Count().Should().Be(1);
-            result.Single().FirstName.Should().Be("ChangesForReview");
+            result.Results.Count.Should().Be(1);
+            result.Results.Single().FirstName.Should().Be("ChangesForReview");
         }
 
         [TestCase(Originator.Provider)]
@@ -237,8 +236,8 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service
             var query = new ApprenticeshipSearchQuery { TrainingCourses = new List<string>(new [] { "123-00-009", "35", "2" } )};
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Count().Should().Be(1);
-            result.Single().Id.Should().Be(009);
+            result.Results.Count.Should().Be(1);
+            result.Results.Single().Id.Should().Be(009);
         }
 
         [TestCase(Originator.Provider)]
@@ -264,7 +263,7 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service
             var query = new ApprenticeshipSearchQuery { TrainingCourses = new List<string>(new[] { "123-00-009", "35", "2" }) };
             var result = _sut.Filter(_apprenticeships, query, caller);
 
-            result.Count().Should().Be(0);
+            result.Results.Count.Should().Be(0);
         }
 
 
@@ -295,8 +294,8 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service
             var query = new ApprenticeshipSearchQuery { EmployerOrganisationIds = new List<string> { "09990" } };
             var result = _sut.Filter(_apprenticeships, query, Originator.Provider);
 
-            result.Count().Should().Be(1);
-            result.FirstOrDefault().LegalEntityName.Should().Be("Employer 999");
+            result.Results.Count.Should().Be(1);
+            result.Results.FirstOrDefault().LegalEntityName.Should().Be("Employer 999");
         }
 
         [Test]
@@ -324,7 +323,7 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service
             var query = new ApprenticeshipSearchQuery { EmployerOrganisationIds = new List<string> { "999" } };
             var result = _sut.Filter(_apprenticeships, query, Originator.Employer);
 
-            result.Count().Should().Be(_apprenticeships.Count);
+            result.Results.Count.Should().Be(_apprenticeships.Count);
         }
 
         [Test]
@@ -356,8 +355,8 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service
             var query = new ApprenticeshipSearchQuery { TrainingProviderIds = new List<long> { 007 } };
             var result = _sut.Filter(_apprenticeships, query, Originator.Employer);
 
-            result.Count().Should().Be(1);
-            result.FirstOrDefault().ProviderName.Should().Be("Provider 007");
+            result.Results.Count.Should().Be(1);
+            result.Results.FirstOrDefault().ProviderName.Should().Be("Provider 007");
         }
 
         [Test]
@@ -389,8 +388,111 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Service
             var query = new ApprenticeshipSearchQuery { TrainingProviderIds = new List<long> { 007 } };
             var result = _sut.Filter(_apprenticeships, query, Originator.Provider);
 
-            result.Count().Should().Be(_apprenticeships.Count);
+            result.Results.Count.Should().Be(_apprenticeships.Count);
         }
 
+        [Test]
+        public void ShouldReturnFirstPageOfApprenticeships()
+        {
+            const int RequestedPageNumber = 1;
+            const int RequestedPageSize = 4;
+
+            var apprenticeships = CreatePaginiationApprenticeships(20);
+            var query = new ApprenticeshipSearchQuery { PageNumber = RequestedPageNumber, PageSize = RequestedPageSize };
+
+            var result = _sut.Filter(apprenticeships, query, Originator.Provider);
+
+            result.Results.Count.Should().Be(RequestedPageSize);
+            result.Results.Select(x => x.Id).ShouldAllBeEquivalentTo(new List<int> { 1, 2, 3, 4 });
+        }
+
+        [Test]
+        public void ShouldReturnSecondPageOfApprenticeships()
+        {
+            const int RequestedPageNumber = 2;
+            const int RequestedPageSize = 4;
+
+            var apprenticeships = CreatePaginiationApprenticeships(20);
+            var query = new ApprenticeshipSearchQuery { PageNumber = RequestedPageNumber, PageSize = RequestedPageSize };
+
+            var result = _sut.Filter(apprenticeships, query, Originator.Provider);
+
+            result.Results.Count.Should().Be(RequestedPageSize);
+            result.Results.Select(x => x.Id).ShouldAllBeEquivalentTo(new List<int> { 5, 6, 7, 8 });
+        }
+
+        [Test]
+        public void ShouldReturnFullPageForLastPage()
+        {
+            const int RequestedPageNumber = 5;
+            const int RequestedPageSize = 4;
+
+            var apprenticeships = CreatePaginiationApprenticeships(20);
+            var query = new ApprenticeshipSearchQuery { PageNumber = RequestedPageNumber, PageSize = RequestedPageSize };
+
+            var result = _sut.Filter(apprenticeships, query, Originator.Provider);
+
+            result.Results.Count.Should().Be(RequestedPageSize);
+            result.Results.Select(x => x.Id).ShouldAllBeEquivalentTo(new List<int> { 17, 18, 19, 20 });
+        }
+
+        [Test]
+        public void ShouldReturnPartialPageForLastPage()
+        {
+            const int RequestedPageNumber = 5;
+            const int RequestedPageSize = 4;
+
+            var apprenticeships = CreatePaginiationApprenticeships(18);
+            var query = new ApprenticeshipSearchQuery { PageNumber = RequestedPageNumber, PageSize = RequestedPageSize };
+
+            var result = _sut.Filter(apprenticeships, query, Originator.Provider);
+
+            result.Results.Count.Should().Be(RequestedPageSize - 2);
+            result.Results.Select(x => x.Id).ShouldAllBeEquivalentTo(new List<int> { 17, 18 });
+        }
+
+        [TestCase(1, 100, 10, 1, Description = "Returns first page number if first page number passed in")]
+        [TestCase(14, 100, 10, 10, Description = "Returns last page number if page is not within range of total pages")]
+        [TestCase(10, 100, 10, 10, Description = "Returns page number if page is not within range of total pages")]
+        [TestCase(0, 100, 10, 1, Description = "Returns first page if page is not set (0)")]
+        public void ShouldReturnThePageNumber(int requestedPageNumber, int totalApprenticeships, int requestedPageSize, int expectedPageNumber)
+        {
+            var apprenticeships = CreatePaginiationApprenticeships(totalApprenticeships);
+
+            var query = new ApprenticeshipSearchQuery { PageNumber = requestedPageNumber, PageSize = requestedPageSize };
+
+            var result = _sut.Filter(apprenticeships, query, Originator.Provider);
+
+            result.PageNumber.Should().Be(expectedPageNumber);
+        }
+
+        [TestCase(5, 5, Description = "Returns page size from query if > 0")]
+        [TestCase(0, 25, Description = "Defaults page size to 25 if the page size is not set (0)")]
+        public void ShouldReturnThePageSize(int requestedPageSize, int expectedPageSize)
+        {
+            var apprenticeships = CreatePaginiationApprenticeships(20);
+
+            var query = new ApprenticeshipSearchQuery { PageNumber = 1, PageSize = requestedPageSize };
+
+            var result = _sut.Filter(apprenticeships, query, Originator.Provider);
+
+            result.PageSize.Should().Be(expectedPageSize);
+        }
+
+        private static IList<Apprenticeship> CreatePaginiationApprenticeships(int count)
+        {
+            var apprenticeships = new List<Apprenticeship>(count);
+
+            for (int i = 1; i <= count; i++)
+            {
+                apprenticeships.Add(new Apprenticeship
+                {
+                    Id = i,
+                    PaymentStatus = PaymentStatus.Active
+                });
+            }
+
+            return apprenticeships;
+        }
     }
 }

--- a/src/SFA.DAS.Commitments.Application.UnitTests/packages.config
+++ b/src/SFA.DAS.Commitments.Application.UnitTests/packages.config
@@ -9,7 +9,7 @@
   <package id="Moq" version="4.5.21" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="NUnit" version="3.4.1" targetFramework="net45" />
-  <package id="SFA.DAS.Commitments.Api.Types" version="1.66.0.33236" targetFramework="net45" />
+  <package id="SFA.DAS.Commitments.Api.Types" version="1.67.0.34274" targetFramework="net45" />
   <package id="SFA.DAS.Events.Api.Client" version="1.26.0.33437" targetFramework="net45" />
   <package id="SFA.DAS.Events.Api.Types" version="1.26.0.33437" targetFramework="net45" />
   <package id="StructureMap" version="4.4.5" targetFramework="net45" />

--- a/src/SFA.DAS.Commitments.Application/Queries/GetApprenticeships/GetApprenticeshipsRequest.cs
+++ b/src/SFA.DAS.Commitments.Application/Queries/GetApprenticeships/GetApprenticeshipsRequest.cs
@@ -5,8 +5,11 @@ namespace SFA.DAS.Commitments.Application.Queries.GetApprenticeships
 {
     public sealed class GetApprenticeshipsRequest : IAsyncRequest<GetApprenticeshipsResponse>
     {
-        public Caller Caller { get; set; }
+        public const int DefaultPageNumber = 1;
+        public const int DefaultPageSize = 25;
 
-        //todo: add paging
+        public Caller Caller { get; set; }
+        public int PageNumber { get; set; }
+        public int PageSize { get; set; }
     }
 }

--- a/src/SFA.DAS.Commitments.Application/Queries/GetApprenticeships/GetApprenticeshipsRequest.cs
+++ b/src/SFA.DAS.Commitments.Application/Queries/GetApprenticeships/GetApprenticeshipsRequest.cs
@@ -5,11 +5,6 @@ namespace SFA.DAS.Commitments.Application.Queries.GetApprenticeships
 {
     public sealed class GetApprenticeshipsRequest : IAsyncRequest<GetApprenticeshipsResponse>
     {
-        public const int DefaultPageNumber = 1;
-        public const int DefaultPageSize = 25;
-
         public Caller Caller { get; set; }
-        public int PageNumber { get; set; }
-        public int PageSize { get; set; }
     }
 }

--- a/src/SFA.DAS.Commitments.Application/SFA.DAS.Commitments.Application.csproj
+++ b/src/SFA.DAS.Commitments.Application/SFA.DAS.Commitments.Application.csproj
@@ -46,9 +46,8 @@
     <Reference Include="NLog">
       <HintPath>..\packages\NLog.4.3.9\lib\net45\NLog.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.Commitments.Api.Types, Version=1.66.0.33236, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Commitments.Api.Types.1.66.0.33236\lib\net45\SFA.DAS.Commitments.Api.Types.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="SFA.DAS.Commitments.Api.Types, Version=1.67.0.34274, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Commitments.Api.Types.1.67.0.34274\lib\net45\SFA.DAS.Commitments.Api.Types.dll</HintPath>
     </Reference>
     <Reference Include="SFA.DAS.Events.Api.Types, Version=1.26.0.33437, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Events.Api.Types.1.26.0.33437\lib\net45\SFA.DAS.Events.Api.Types.dll</HintPath>

--- a/src/SFA.DAS.Commitments.Application/Services/ApprenticeshipFilterService.cs
+++ b/src/SFA.DAS.Commitments.Application/Services/ApprenticeshipFilterService.cs
@@ -79,11 +79,11 @@ namespace SFA.DAS.Commitments.Application.Services
 
             var filteredResults = result.ToList();
 
-            var pageSize = apprenticeshipQuery.PageSize == 0 ? 25 : apprenticeshipQuery.PageSize;
+            var pageSize = apprenticeshipQuery.PageSize <= 0 ? 25 : apprenticeshipQuery.PageSize;
             var pageNumber = DeterminePageNumber(apprenticeshipQuery.PageNumber, pageSize, result);
 
             filteredResults = filteredResults
-                .Skip(apprenticeshipQuery.PageSize * (apprenticeshipQuery.PageNumber - 1))
+                .Skip(apprenticeshipQuery.PageSize * (pageNumber - 1))
                 .Take(apprenticeshipQuery.PageSize)
                 .ToList();
 
@@ -92,7 +92,7 @@ namespace SFA.DAS.Commitments.Application.Services
 
         private static int DeterminePageNumber(int pageNumber, int pageSize, IEnumerable<Apprenticeship> approvedApprenticeships)
         {
-            if (pageNumber == 0)
+            if (pageNumber <= 0)
                 return 1;
 
             var totalPages = (approvedApprenticeships.Count() + pageSize - 1) / pageSize;

--- a/src/SFA.DAS.Commitments.Application/Services/ApprenticeshipFilterService.cs
+++ b/src/SFA.DAS.Commitments.Application/Services/ApprenticeshipFilterService.cs
@@ -78,6 +78,7 @@ namespace SFA.DAS.Commitments.Application.Services
             }
 
             var filteredResults = result.ToList();
+            var totalResults = filteredResults.Count;
 
             var pageSize = apprenticeshipQuery.PageSize <= 0 ? 25 : apprenticeshipQuery.PageSize;
             var pageNumber = DeterminePageNumber(apprenticeshipQuery.PageNumber, pageSize, result);
@@ -87,7 +88,7 @@ namespace SFA.DAS.Commitments.Application.Services
                 .Take(apprenticeshipQuery.PageSize)
                 .ToList();
 
-            return new FilterResult(filteredResults, pageNumber, pageSize);
+            return new FilterResult(totalResults, filteredResults, pageNumber, pageSize);
         }
 
         private static int DeterminePageNumber(int pageNumber, int pageSize, IEnumerable<Apprenticeship> approvedApprenticeships)
@@ -106,17 +107,20 @@ namespace SFA.DAS.Commitments.Application.Services
 
     public class FilterResult
     {
-        public FilterResult(List<Apprenticeship> results, int pageNumber, int pageSize)
+        public FilterResult(int totalResults, List<Apprenticeship> pageOfResults, int pageNumber, int pageSize)
         {
-            Results = results;
+            PageOfResults = pageOfResults;
             PageNumber = pageNumber;
             PageSize = pageSize;
+            TotalResults = totalResults;
         }
 
-        public IReadOnlyCollection<Apprenticeship> Results { get; private set; }
+        public IReadOnlyCollection<Apprenticeship> PageOfResults { get; private set; }
 
         public int PageNumber { get; private set; }
 
         public int PageSize { get; private set; }
+
+        public int TotalResults { get; private set; }
     }
 }

--- a/src/SFA.DAS.Commitments.Application/packages.config
+++ b/src/SFA.DAS.Commitments.Application/packages.config
@@ -3,6 +3,6 @@
   <package id="FluentValidation" version="6.2.1.0" targetFramework="net452" />
   <package id="MediatR" version="2.1.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="SFA.DAS.Commitments.Api.Types" version="1.66.0.33236" targetFramework="net45" />
+  <package id="SFA.DAS.Commitments.Api.Types" version="1.67.0.34274" targetFramework="net45" />
   <package id="SFA.DAS.Events.Api.Types" version="1.26.0.33437" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This is a breaking change for the Manage Apprenticeship Search request. Consequence is that it will only return the first 25 results by default.