### PR TITLE
Marking all ApprenticeshipUpdateds as deleted

### DIFF
--- a/src/SFA.DAS.Commitments.Database/PostDeployment/PostDeploymentScript.sql
+++ b/src/SFA.DAS.Commitments.Database/PostDeployment/PostDeploymentScript.sql
@@ -16,14 +16,6 @@ INSERT INTO [dbo].[PriceHistory]
 	WHERE PaymentStatus <> 0
 	AND Id NOT IN (SELECT ApprenticeshipId FROM [dbo].[PriceHistory])
 
--- Setting ApprenticeshipUpdate (CoC) to deleted if 
--- From DataLock origin and Satus is pending
--- The DataLock should still be marked as a TriageChange and be picked by Employer.
-UPDATE dbo.ApprenticeshipUpdate
-SET Status = 3 -- Delete
-WHERE UpdateOrigin = 2 -- DataLock
-AND Status = 0 -- Pending
-
 -- Can remove ApprenticeshipUpdateId if we want.
 UPDATE dbo.DataLockStatus
 SET ApprenticeshipUpdateId = NULL
@@ -31,3 +23,11 @@ WHERE ApprenticeshipUpdateId in
 	(SELECT Id FROM dbo.ApprenticeshipUpdate
 		WHERE UpdateOrigin = 2 -- DataLock
 		AND Status = 0) -- Pending
+		
+-- Setting ApprenticeshipUpdate (CoC) to deleted if 
+-- From DataLock origin and Satus is pending
+-- The DataLock should still be marked as a TriageChange and be picked by Employer.
+UPDATE dbo.ApprenticeshipUpdate
+SET Status = 3 -- Delete
+WHERE UpdateOrigin = 2 -- DataLock
+AND Status = 0 -- Pending

--- a/src/SFA.DAS.Commitments.Database/PostDeployment/PostDeploymentScript.sql
+++ b/src/SFA.DAS.Commitments.Database/PostDeployment/PostDeploymentScript.sql
@@ -16,3 +16,18 @@ INSERT INTO [dbo].[PriceHistory]
 	WHERE PaymentStatus <> 0
 	AND Id NOT IN (SELECT ApprenticeshipId FROM [dbo].[PriceHistory])
 
+-- Setting ApprenticeshipUpdate (CoC) to deleted if 
+-- From DataLock origin and Satus is pending
+-- The DataLock should still be marked as a TriageChange and be picked by Employer.
+UPDATE dbo.ApprenticeshipUpdate
+SET Status = 3 -- Delete
+WHERE UpdateOrigin = 2 -- DataLock
+AND Status = 0 -- Pending
+
+-- Can remove ApprenticeshipUpdateId if we want.
+UPDATE dbo.DataLockStatus
+SET ApprenticeshipUpdateId = NULL
+WHERE ApprenticeshipUpdateId in 
+	(SELECT Id FROM dbo.ApprenticeshipUpdate
+		WHERE UpdateOrigin = 2 -- DataLock
+		AND Status = 0) -- Pending


### PR DESCRIPTION
Maybe we want to run thins after deployment of DL 2.0.
I think otherwise the Employer will see the data lock and the CoC. 

Commit:
- if they are from DataLock and Pending
Removing ref to ApprenticeshipUpdate on DataLock
from -> release_10-07-2017_DL-V2)