### PR TITLE
DCM-447 -> Added session id to notification WebJob

### DIFF
--- a/src/SFA.DAS.CommitmentPayments.WebJob.UnitTests/SFA.DAS.CommitmentPayments.WebJob.UnitTests.csproj
+++ b/src/SFA.DAS.CommitmentPayments.WebJob.UnitTests/SFA.DAS.CommitmentPayments.WebJob.UnitTests.csproj
@@ -56,8 +56,8 @@
     <Reference Include="SFA.DAS.Learners, Version=1.0.0.39408, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Learners.1.0.0.39408\lib\net45\SFA.DAS.Learners.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39131, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39131\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="SFA.DAS.Provider.Events.Api.Client, Version=2.0.0.34401, Culture=neutral, processorArchitecture=MSIL">

--- a/src/SFA.DAS.CommitmentPayments.WebJob.UnitTests/packages.config
+++ b/src/SFA.DAS.CommitmentPayments.WebJob.UnitTests/packages.config
@@ -9,6 +9,6 @@
   <package id="NUnit" version="3.4.1" targetFramework="net452" />
   <package id="Polly" version="5.1.0" targetFramework="net452" />
   <package id="SFA.DAS.Learners" version="1.0.0.39408" targetFramework="net452" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39131" targetFramework="net452" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net452" />
   <package id="SFA.DAS.Provider.Events.Api.Client" version="2.0.0.34401" targetFramework="net452" />
 </packages>

--- a/src/SFA.DAS.CommitmentPayments.WebJob/SFA.DAS.CommitmentPayments.WebJob.csproj
+++ b/src/SFA.DAS.CommitmentPayments.WebJob/SFA.DAS.CommitmentPayments.WebJob.csproj
@@ -87,8 +87,8 @@
     <Reference Include="SFA.DAS.Learners, Version=1.0.0.39408, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Learners.1.0.0.39408\lib\net45\SFA.DAS.Learners.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39131, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39131\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="SFA.DAS.NLog.Targets.Redis, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">

--- a/src/SFA.DAS.CommitmentPayments.WebJob/packages.config
+++ b/src/SFA.DAS.CommitmentPayments.WebJob/packages.config
@@ -18,7 +18,7 @@
   <package id="SFA.DAS.Configuration" version="1.0.0.14492" targetFramework="net452" />
   <package id="SFA.DAS.Configuration.AzureTableStorage" version="1.0.0.14492" targetFramework="net452" />
   <package id="SFA.DAS.Learners" version="1.0.0.39408" targetFramework="net452" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39131" targetFramework="net452" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net452" />
   <package id="SFA.DAS.NLog.Targets.Redis" version="1.0.0.34273" targetFramework="net452" />
   <package id="SFA.DAS.Provider.Events.Api.Client" version="2.0.0.34401" targetFramework="net452" />
   <package id="SFA.DAS.Sql.Client" version="1.0.0.32930" targetFramework="net452" />

--- a/src/SFA.DAS.Commitments.Api.Client.UnitTests/SFA.DAS.Commitments.Api.Client.UnitTests.csproj
+++ b/src/SFA.DAS.Commitments.Api.Client.UnitTests/SFA.DAS.Commitments.Api.Client.UnitTests.csproj
@@ -67,8 +67,8 @@
       <HintPath>..\packages\NUnit.3.4.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SFA.DAS.Http, Version=1.0.0.35788, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Http.1.0.0.35788\lib\net45\SFA.DAS.Http.dll</HintPath>
+    <Reference Include="SFA.DAS.Http, Version=1.0.0.39136, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Http.1.0.0.39136\lib\net45\SFA.DAS.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/SFA.DAS.Commitments.Api.Client.UnitTests/packages.config
+++ b/src/SFA.DAS.Commitments.Api.Client.UnitTests/packages.config
@@ -7,5 +7,5 @@
   <package id="Moq" version="4.5.21" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
   <package id="NUnit" version="3.4.1" targetFramework="net452" />
-  <package id="SFA.DAS.Http" version="1.0.0.35788" targetFramework="net452" />
+  <package id="SFA.DAS.Http" version="1.0.0.39136" targetFramework="net452" />
 </packages>

--- a/src/SFA.DAS.Commitments.Api.Client/SFA.DAS.Commitments.Api.Client.csproj
+++ b/src/SFA.DAS.Commitments.Api.Client/SFA.DAS.Commitments.Api.Client.csproj
@@ -44,8 +44,8 @@
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SFA.DAS.Http, Version=1.0.0.35788, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Http.1.0.0.35788\lib\net45\SFA.DAS.Http.dll</HintPath>
+    <Reference Include="SFA.DAS.Http, Version=1.0.0.39136, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Http.1.0.0.39136\lib\net45\SFA.DAS.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/SFA.DAS.Commitments.Api.Client/packages.config
+++ b/src/SFA.DAS.Commitments.Api.Client/packages.config
@@ -10,5 +10,5 @@
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.4.0" targetFramework="net45" />
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.0" targetFramework="net45" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.4.0" targetFramework="net45" />
-  <package id="SFA.DAS.Http" version="1.0.0.35788" targetFramework="net45" />
+  <package id="SFA.DAS.Http" version="1.0.0.39136" targetFramework="net45" />
 </packages>

--- a/src/SFA.DAS.Commitments.Api/SFA.DAS.Commitments.Api.csproj
+++ b/src/SFA.DAS.Commitments.Api/SFA.DAS.Commitments.Api.csproj
@@ -178,8 +178,8 @@
     <Reference Include="SFA.DAS.Learners, Version=1.0.0.39408, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Learners.1.0.0.39408\lib\net45\SFA.DAS.Learners.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39131, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39131\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="SFA.DAS.NLog.Targets.Redis, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">

--- a/src/SFA.DAS.Commitments.Api/packages.config
+++ b/src/SFA.DAS.Commitments.Api/packages.config
@@ -51,7 +51,7 @@
   <package id="SFA.DAS.Events.Api.Client" version="2.0.0.35796" targetFramework="net45" />
   <package id="SFA.DAS.Events.Api.Types" version="2.0.0.35796" targetFramework="net45" />
   <package id="SFA.DAS.Learners" version="1.0.0.39408" targetFramework="net45" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39131" targetFramework="net45" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net45" />
   <package id="SFA.DAS.NLog.Targets.Redis" version="1.0.0.34273" targetFramework="net45" />
   <package id="SFA.DAS.Sql.Client" version="1.0.0.32930" targetFramework="net45" />
   <package id="StackExchange.Redis" version="1.1.608" targetFramework="net45" />

--- a/src/SFA.DAS.Commitments.Domain/SFA.DAS.Commitments.Domain.csproj
+++ b/src/SFA.DAS.Commitments.Domain/SFA.DAS.Commitments.Domain.csproj
@@ -46,8 +46,8 @@
       <HintPath>..\packages\SFA.DAS.Events.Api.Types.2.0.0.35796\lib\net45\SFA.DAS.Events.Api.Types.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39131, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39131\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/SFA.DAS.Commitments.Domain/packages.config
+++ b/src/SFA.DAS.Commitments.Domain/packages.config
@@ -6,5 +6,5 @@
   <package id="NLog" version="4.3.7" targetFramework="net45" />
   <package id="SFA.DAS.Events.Api.Client" version="2.0.0.35796" targetFramework="net45" />
   <package id="SFA.DAS.Events.Api.Types" version="2.0.0.35796" targetFramework="net45" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39131" targetFramework="net45" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net45" />
 </packages>

--- a/src/SFA.DAS.Commitments.Infrastructure.UnitTests/SFA.DAS.Commitments.Infrastructure.UnitTests.csproj
+++ b/src/SFA.DAS.Commitments.Infrastructure.UnitTests/SFA.DAS.Commitments.Infrastructure.UnitTests.csproj
@@ -70,8 +70,8 @@
     <Reference Include="SFA.DAS.Learners, Version=1.0.0.39408, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Learners.1.0.0.39408\lib\net45\SFA.DAS.Learners.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39131, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39131\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="SFA.DAS.Provider.Events.Api.Client, Version=2.0.0.34401, Culture=neutral, processorArchitecture=MSIL">

--- a/src/SFA.DAS.Commitments.Infrastructure.UnitTests/packages.config
+++ b/src/SFA.DAS.Commitments.Infrastructure.UnitTests/packages.config
@@ -11,6 +11,6 @@
   <package id="SFA.DAS.Events.Api.Client" version="2.0.0.35796" targetFramework="net45" />
   <package id="SFA.DAS.Events.Api.Types" version="2.0.0.35796" targetFramework="net45" />
   <package id="SFA.DAS.Learners" version="1.0.0.39408" targetFramework="net45" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39131" targetFramework="net45" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net45" />
   <package id="SFA.DAS.Provider.Events.Api.Client" version="2.0.0.34401" targetFramework="net45" />
 </packages>

--- a/src/SFA.DAS.Commitments.Infrastructure/SFA.DAS.Commitments.Infrastructure.csproj
+++ b/src/SFA.DAS.Commitments.Infrastructure/SFA.DAS.Commitments.Infrastructure.csproj
@@ -85,8 +85,8 @@
     <Reference Include="SFA.DAS.Learners, Version=1.0.0.39408, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Learners.1.0.0.39408\lib\net45\SFA.DAS.Learners.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39131, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39131\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="SFA.DAS.Provider.Events.Api.Client, Version=2.0.0.34401, Culture=neutral, processorArchitecture=MSIL">

--- a/src/SFA.DAS.Commitments.Infrastructure/packages.config
+++ b/src/SFA.DAS.Commitments.Infrastructure/packages.config
@@ -15,7 +15,7 @@
   <package id="SFA.DAS.Events.Api.Client" version="2.0.0.35796" targetFramework="net45" />
   <package id="SFA.DAS.Events.Api.Types" version="2.0.0.35796" targetFramework="net45" />
   <package id="SFA.DAS.Learners" version="1.0.0.39408" targetFramework="net45" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39131" targetFramework="net45" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net45" />
   <package id="SFA.DAS.Provider.Events.Api.Client" version="2.0.0.34401" targetFramework="net45" />
   <package id="SFA.DAS.Sql.Client" version="1.0.0.32930" targetFramework="net45" />
   <package id="structuremap" version="4.2.0.402" targetFramework="net45" />

--- a/src/SFA.DAS.Commitments.Notification.WebJob.UnitTests/SFA.DAS.Commitments.Notification.WebJob.UnitTests.csproj
+++ b/src/SFA.DAS.Commitments.Notification.WebJob.UnitTests/SFA.DAS.Commitments.Notification.WebJob.UnitTests.csproj
@@ -86,15 +86,15 @@
     <Reference Include="SFA.DAS.EAS.Account.Api.Types, Version=1.0.0.32731, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Account.Api.Types.1.0.0.32731\lib\net45\SFA.DAS.EAS.Account.Api.Types.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.Http, Version=1.0.0.35788, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Http.1.0.0.35788\lib\net45\SFA.DAS.Http.dll</HintPath>
+    <Reference Include="SFA.DAS.Http, Version=1.0.0.39136, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Http.1.0.0.39136\lib\net45\SFA.DAS.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="SFA.DAS.Learners, Version=1.0.0.39408, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Learners.1.0.0.39408\lib\net45\SFA.DAS.Learners.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39131, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39131\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="SFA.DAS.Notifications.Api.Client, Version=1.2.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/SFA.DAS.Commitments.Notification.WebJob.UnitTests/packages.config
+++ b/src/SFA.DAS.Commitments.Notification.WebJob.UnitTests/packages.config
@@ -13,9 +13,9 @@
   <package id="NUnit" version="3.4.1" targetFramework="net452" />
   <package id="SFA.DAS.Account.Api.Client" version="1.0.0.32731" targetFramework="net452" />
   <package id="SFA.DAS.Account.Api.Types" version="1.0.0.32731" targetFramework="net452" />
-  <package id="SFA.DAS.Http" version="1.0.0.35788" targetFramework="net452" />
+  <package id="SFA.DAS.Http" version="1.0.0.39136" targetFramework="net452" />
   <package id="SFA.DAS.Learners" version="1.0.0.39408" targetFramework="net452" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39131" targetFramework="net452" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net452" />
   <package id="SFA.DAS.Notifications.Api.Client" version="2.0.0.35919" targetFramework="net452" />
   <package id="SFA.DAS.Notifications.Api.Types" version="2.0.0.35919" targetFramework="net452" />
   <package id="SFA.DAS.PAS.Account.Api.Client" version="1.0.0.40430" targetFramework="net452" />

--- a/src/SFA.DAS.Commitments.Notification.WebJob/App.config
+++ b/src/SFA.DAS.Commitments.Notification.WebJob/App.config
@@ -17,7 +17,7 @@
       <add assembly="SFA.DAS.NLog.Targets.Redis" />
       <add assembly="Microsoft.ApplicationInsights.NLogTarget" />
     </extensions>
-    <variable name="simplelayout" value="${longdate} [${uppercase:${level}}] [${logger}] - ${message} ${onexception:${exception:format=tostring}}" />
+    <variable name="simplelayout" value="${longdate} [${uppercase:${level}}] [${logger}] - ${message} ${onexception:${exception:format=tostring}} --&gt; ${all-event-properties}" />
     <variable name="appName" value="das-commitmentnotification-webjob" />
     <targets>
       <target xsi:type="File" name="Disk" fileName="${basedir}/logs/${appName}.${shortdate}.log" layout="${simplelayout}" />

--- a/src/SFA.DAS.Commitments.Notification.WebJob/DependencyResolution/DefaultRegistry.cs
+++ b/src/SFA.DAS.Commitments.Notification.WebJob/DependencyResolution/DefaultRegistry.cs
@@ -17,6 +17,7 @@ using SFA.DAS.Commitments.Infrastructure.Configuration;
 using SFA.DAS.Commitments.Infrastructure.Services;
 using SFA.DAS.Commitments.Notification.WebJob.Services;
 using SFA.DAS.Http.TokenGenerators;
+using SFA.DAS.NLog.Logger.Web.MessageHandlers;
 using SFA.DAS.Notifications.Api.Client;
 
 namespace SFA.DAS.Commitments.Notification.WebJob.DependencyResolution
@@ -64,6 +65,8 @@ namespace SFA.DAS.Commitments.Notification.WebJob.DependencyResolution
             {
                 httpClient = new Http.HttpClientBuilder()
                 .WithBearerAuthorisationHeader(new JwtBearerTokenGenerator(config.NotificationApi))
+                .WithHandler(new SessionIdMessageRequestHandler())
+                .WithDefaultHeaders()
                 .Build();
             }
             else

--- a/src/SFA.DAS.Commitments.Notification.WebJob/NotificationJob.cs
+++ b/src/SFA.DAS.Commitments.Notification.WebJob/NotificationJob.cs
@@ -91,11 +91,12 @@ namespace SFA.DAS.Commitments.Notification.WebJob
             }
 
             var stopwatch = Stopwatch.StartNew();
-
+            
             _logger.Debug($"About to send {emailsToSendCount} emails, JobId: {jobId}");
 
             
             var tasks = emails.Select(email => _notificationsApi.SendEmail(email));
+            
             await Task.WhenAll(tasks);
             
 

--- a/src/SFA.DAS.Commitments.Notification.WebJob/Program.cs
+++ b/src/SFA.DAS.Commitments.Notification.WebJob/Program.cs
@@ -1,8 +1,11 @@
-﻿using SFA.DAS.Commitments.Notification.WebJob.Configuration;
+﻿using System;
+using System.Threading.Tasks;
+
+using NLog;
+
+using SFA.DAS.Commitments.Notification.WebJob.Configuration;
 using SFA.DAS.Commitments.Notification.WebJob.DependencyResolution;
 using SFA.DAS.NLog.Logger;
-using System;
-using System.Threading.Tasks;
 
 namespace SFA.DAS.Commitments.Notification.WebJob
 {
@@ -19,6 +22,8 @@ namespace SFA.DAS.Commitments.Notification.WebJob
             var config = container.GetInstance<CommitmentNotificationConfiguration>();
             var notificationJob = container.GetInstance<INotificationJob>();
             var notificationJobId = $"Notification.WJ.{DateTime.UtcNow.Ticks}";
+            MappedDiagnosticsLogicalContext.Set(Constants.HeaderNameSessionCorrelationId, notificationJobId);
+
             if (!config.EnableJob)
             {
                 logger.Info($"CommitmentNotification.WebJob job is turned off, JobId: {notificationJobId}");

--- a/src/SFA.DAS.Commitments.Notification.WebJob/SFA.DAS.Commitments.Notification.WebJob.csproj
+++ b/src/SFA.DAS.Commitments.Notification.WebJob/SFA.DAS.Commitments.Notification.WebJob.csproj
@@ -105,15 +105,15 @@
     <Reference Include="SFA.DAS.EAS.Account.Api.Types, Version=1.0.0.32731, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Account.Api.Types.1.0.0.32731\lib\net45\SFA.DAS.EAS.Account.Api.Types.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.Http, Version=1.0.0.35788, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.Http.1.0.0.35788\lib\net45\SFA.DAS.Http.dll</HintPath>
+    <Reference Include="SFA.DAS.Http, Version=1.0.0.39136, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Http.1.0.0.39136\lib\net45\SFA.DAS.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="SFA.DAS.Learners, Version=1.0.0.39408, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Learners.1.0.0.39408\lib\net45\SFA.DAS.Learners.dll</HintPath>
     </Reference>
-    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39131, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39131\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="SFA.DAS.NLog.Targets.Redis, Version=1.0.0.34273, Culture=neutral, processorArchitecture=MSIL">

--- a/src/SFA.DAS.Commitments.Notification.WebJob/packages.config
+++ b/src/SFA.DAS.Commitments.Notification.WebJob/packages.config
@@ -21,9 +21,9 @@
   <package id="SFA.DAS.Account.Api.Types" version="1.0.0.32731" targetFramework="net452" />
   <package id="SFA.DAS.Configuration" version="1.0.0.14492" targetFramework="net452" />
   <package id="SFA.DAS.Configuration.AzureTableStorage" version="1.0.0.14492" targetFramework="net452" />
-  <package id="SFA.DAS.Http" version="1.0.0.35788" targetFramework="net452" />
+  <package id="SFA.DAS.Http" version="1.0.0.39136" targetFramework="net452" />
   <package id="SFA.DAS.Learners" version="1.0.0.39408" targetFramework="net452" />
-  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39131" targetFramework="net452" />
+  <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net452" />
   <package id="SFA.DAS.NLog.Targets.Redis" version="1.0.0.34273" targetFramework="net452" />
   <package id="SFA.DAS.Notifications.Api.Client" version="2.0.0.35919" targetFramework="net452" />
   <package id="SFA.DAS.Notifications.Api.Types" version="2.0.0.35919" targetFramework="net452" />


### PR DESCRIPTION
Sending session id to notification API to be able to track all email sent from a Notifications WebJob.
Employer and Provider will share the same correlation id = 1 job 1 Id.