### PR TITLE
Fix for posting start date for event to resume awaiting apprenticeship

### DIFF
--- a/src/SFA.DAS.Commitments.Application.UnitTests/Commands/UpdateApprenticeshipStatus/WhenResumingApprenticeship.cs
+++ b/src/SFA.DAS.Commitments.Application.UnitTests/Commands/UpdateApprenticeshipStatus/WhenResumingApprenticeship.cs
@@ -38,26 +38,7 @@ namespace SFA.DAS.Commitments.Application.UnitTests.Commands.UpdateApprenticeshi
         }
 
         [Test]
-        public async Task ThenShouldSendAnApprenticeshipEventWithStartDate()
-        {
-            MockCommitmentRespository.Setup(x => x.GetCommitmentById(It.IsAny<long>())).ReturnsAsync(new Commitment
-            {
-                Id = 123L,
-                EmployerAccountId = ExampleValidRequest.AccountId
-            });
-            
-            await Handler.Handle(ExampleValidRequest);
-
-            MockEventsApi.Verify(x => x.PublishChangeApprenticeshipStatusEvent(
-                It.IsAny<Commitment>(),
-                It.IsAny<Apprenticeship>(),
-                It.Is<PaymentStatus>(a => a == PaymentStatus.Active),
-                It.Is<DateTime?>(a => a.Equals(TestApprenticeship.StartDate)),
-                null));
-        }
-
-        [Test]
-        public async Task WhenAwaitingThenShouldSendAnApprenticeshipEventWithDateOfChange()
+        public async Task WhenAwaitingThenShouldSendAnApprenticeshipEventWithStartDate()
         {
             MockCommitmentRespository.Setup(x => x.GetCommitmentById(It.IsAny<long>())).ReturnsAsync(new Commitment
             {

--- a/src/SFA.DAS.Commitments.Application/Commands/UpdateApprenticeshipStatus/UpdateApprenticeshipStatusCommandHandler.cs
+++ b/src/SFA.DAS.Commitments.Application/Commands/UpdateApprenticeshipStatus/UpdateApprenticeshipStatusCommandHandler.cs
@@ -74,10 +74,12 @@ namespace SFA.DAS.Commitments.Application.Commands.UpdateApprenticeshipStatus
 
         private async Task CreateEvent(UpdateApprenticeshipStatusCommand command, Apprenticeship apprenticeship, Commitment commitment, PaymentStatus newPaymentStatus)
         {
-            var isResuming = (newPaymentStatus == PaymentStatus.Active && apprenticeship.PauseDate.HasValue);
+            var apprenticeshipHasStarted = apprenticeship.StartDate.Value.Date < _currentDate.Now.Date;
+            var resumingApprenticeship = (newPaymentStatus == PaymentStatus.Active && apprenticeship.PauseDate.HasValue);
+
             if (newPaymentStatus == PaymentStatus.Paused ||
                 newPaymentStatus == PaymentStatus.Withdrawn ||
-                isResuming
+                (resumingApprenticeship && apprenticeshipHasStarted)
             )
             {
                 await _eventsApi.PublishChangeApprenticeshipStatusEvent(commitment, apprenticeship, newPaymentStatus, effectiveFrom: command.DateOfChange.Date);


### PR DESCRIPTION
One change to raising event for resuming apprenticeship under academic year rules. 

One renamed unit test, one new unit test, refactored conditional in CreateEvent method.

