### PR TITLE
Revert change to stored proc

### DIFF
--- a/src/SFA.DAS.Commitments.Database/StoredProcedures/GetCommitment.sql
+++ b/src/SFA.DAS.Commitments.Database/StoredProcedures/GetCommitment.sql
@@ -8,7 +8,7 @@ SELECT
 FROM 
 	[dbo].[CommitmentSummary] c 
 LEFT JOIN 
-	[dbo].[Apprenticeship] a 
+	[dbo].[ApprenticeshipSummary] a 
 ON 
 	a.CommitmentId = c.Id 
 WHERE 


### PR DESCRIPTION
Stored proc was altered to use table instead of view.
The view is required to return all columns required to populate entity.