### PR TITLE
DCM-924 - if the mapper receives a null commitment (which could possi…

### DIFF
--- a/src/SFA.DAS.Commitments.Api.UnitTests/Controllers/EmployerControllerTests/WhenGettingASingleCommitment.cs
+++ b/src/SFA.DAS.Commitments.Api.UnitTests/Controllers/EmployerControllerTests/WhenGettingASingleCommitment.cs
@@ -11,7 +11,6 @@ using FluentValidation;
 using SFA.DAS.Commitments.Api.Orchestrators;
 using SFA.DAS.Commitments.Api.Orchestrators.Mappers;
 using SFA.DAS.Commitments.Api.Types.Commitment;
-using SFA.DAS.Commitments.Application.Services;
 using SFA.DAS.Commitments.Domain;
 using SFA.DAS.Commitments.Domain.Interfaces;
 
@@ -84,6 +83,18 @@ namespace SFA.DAS.Commitments.Api.UnitTests.Controllers.EmployerControllerTests
             _mockMediator.Setup(x => x.SendAsync(It.IsAny<GetCommitmentRequest>())).ReturnsAsync(new GetCommitmentResponse { Data = null });
 
             var result = await _controller.GetCommitment(111L, 0L);
+
+            result.Should().BeOfType<NotFoundResult>();
+        }
+
+        [Test]
+        public async Task ThenReturnsNotFoundWhenOrchestratorReturnsNull()
+        {
+            var orchestrator = new Mock<IEmployerOrchestrator>();
+            orchestrator.Setup(x => x.GetCommitment(It.IsAny<long>(), It.IsAny<long>())).ReturnsAsync(null);
+            var controller = new EmployerController(orchestrator.Object, Mock.Of<IApprenticeshipsOrchestrator>());
+
+            var result = await controller.GetCommitment(1L, 1L);
 
             result.Should().BeOfType<NotFoundResult>();
         }

--- a/src/SFA.DAS.Commitments.Api.UnitTests/Controllers/ProviderControllerTests/WhenGettingASingleCommitment.cs
+++ b/src/SFA.DAS.Commitments.Api.UnitTests/Controllers/ProviderControllerTests/WhenGettingASingleCommitment.cs
@@ -11,7 +11,6 @@ using SFA.DAS.Commitments.Api.Orchestrators;
 using SFA.DAS.Commitments.Api.Orchestrators.Mappers;
 using SFA.DAS.Commitments.Api.Types.Commitment;
 using SFA.DAS.Commitments.Application.Queries.GetCommitment;
-using SFA.DAS.Commitments.Application.Services;
 using SFA.DAS.Commitments.Domain;
 using SFA.DAS.Commitments.Domain.Interfaces;
 
@@ -90,6 +89,18 @@ namespace SFA.DAS.Commitments.Api.UnitTests.Controllers.ProviderControllerTests
             _mockMediator.Setup(x => x.SendAsync(It.IsAny<GetCommitmentRequest>())).ReturnsAsync(new GetCommitmentResponse { Data = null });
 
             var result = await _controller.GetCommitment(111L, 0L);
+
+            result.Should().BeOfType<NotFoundResult>();
+        }
+
+        [Test]
+        public async Task ThenReturnsNotFoundWhenOrchestratorReturnsNull()
+        {
+            var orchestrator = new Mock<IProviderOrchestrator>();
+            orchestrator.Setup(x => x.GetCommitment(It.IsAny<long>(), It.IsAny<long>())).ReturnsAsync(null);
+            var controller = new ProviderController(orchestrator.Object, Mock.Of<IApprenticeshipsOrchestrator>());
+
+            var result = await controller.GetCommitment(1L, 1L);
 
             result.Should().BeOfType<NotFoundResult>();
         }

--- a/src/SFA.DAS.Commitments.Api.UnitTests/Orchestrators/Mappers/WhenMappingACommitment.cs
+++ b/src/SFA.DAS.Commitments.Api.UnitTests/Orchestrators/Mappers/WhenMappingACommitment.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using Moq;
+using NUnit.Framework;
+using SFA.DAS.Commitments.Api.Orchestrators.Mappers;
+using SFA.DAS.Commitments.Application.Rules;
+using SFA.DAS.Commitments.Domain;
+using SFA.DAS.Commitments.Domain.Entities;
+
+namespace SFA.DAS.Commitments.Api.UnitTests.Orchestrators.Mappers
+{
+    [TestFixture]
+    public class WhenMappingACommitment
+    {
+        private ICommitmentRules _rules;
+
+        private CommitmentMapper _mapper;
+
+        [SetUp]
+        public void Setup()
+        {
+            _rules = Mock.Of<ICommitmentRules>();
+            _mapper = new CommitmentMapper(_rules);
+        }
+        [Test]
+        public void ThenMappingCompletesSuccessfully()
+        {
+            var apprenticeship = new Domain.Entities.Apprenticeship
+            {
+                Cost = null,
+                AgreedOn = null,
+                DateOfBirth = null,
+                EndDate = null,
+                EmployerRef = null,
+                FirstName = null,
+                PauseDate = null,
+                LastName = null,
+                LegalEntityId = null,
+                LegalEntityName = null,
+                NINumber = null,
+                ProviderName = null,
+                ProviderRef = null,
+                Reference = null,
+                TrainingCode = null,
+                TrainingName = null,
+                StartDate = null,
+                ULN = null,
+                UpdateOriginator = null
+            };
+            var commitment = new Commitment {Apprenticeships = new List<Domain.Entities.Apprenticeship> {apprenticeship} };
+
+            Assert.DoesNotThrow(() => _mapper.MapFrom(commitment, CallerType.Provider));
+        }
+
+        [Test]
+        public void ThenMappingThrowsIfCommitmentNull()
+        {
+            Assert.IsNull(_mapper.MapFrom(null as Commitment, CallerType.Employer));
+        }
+    }
+}

--- a/src/SFA.DAS.Commitments.Api.UnitTests/SFA.DAS.Commitments.Api.UnitTests.csproj
+++ b/src/SFA.DAS.Commitments.Api.UnitTests/SFA.DAS.Commitments.Api.UnitTests.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Orchestrators\Apprenticeship\WhenResolveDataLock.cs" />
     <Compile Include="Orchestrators\Apprenticeship\WhenTriageDataLock.cs" />
     <Compile Include="Orchestrators\Apprenticeship\WhenTriageDataLocks.cs" />
+    <Compile Include="Orchestrators\Mappers\WhenMappingACommitment.cs" />
     <Compile Include="StubCurrentDateTime.cs" />
     <Compile Include="Mapping\Service\ApprenticeshipFilterService\WhenFilterApprenticeships.cs" />
     <Compile Include="Mapping\Service\ApprenticeshipFilterService\WhenPagingFilterResults.cs" />

--- a/src/SFA.DAS.Commitments.Api/Controllers/EmployerController.cs
+++ b/src/SFA.DAS.Commitments.Api/Controllers/EmployerController.cs
@@ -15,10 +15,10 @@ namespace SFA.DAS.Commitments.Api.Controllers
     [RoutePrefix("api/employer")]
     public class EmployerController : ApiController
     {
-        private readonly EmployerOrchestrator _employerOrchestrator;
-        private readonly ApprenticeshipsOrchestrator _apprenticeshipsOrchestrator;
+        private readonly IEmployerOrchestrator _employerOrchestrator;
+        private readonly IApprenticeshipsOrchestrator _apprenticeshipsOrchestrator;
 
-        public EmployerController(EmployerOrchestrator employerOrchestrator, ApprenticeshipsOrchestrator apprenticeshipsOrchestrator)
+        public EmployerController(IEmployerOrchestrator employerOrchestrator, IApprenticeshipsOrchestrator apprenticeshipsOrchestrator)
         {
             if (employerOrchestrator == null)
                 throw new ArgumentNullException(nameof(employerOrchestrator));

--- a/src/SFA.DAS.Commitments.Api/Controllers/ProviderController.cs
+++ b/src/SFA.DAS.Commitments.Api/Controllers/ProviderController.cs
@@ -16,11 +16,11 @@ namespace SFA.DAS.Commitments.Api.Controllers
     [RoutePrefix("api/provider")]
     public class ProviderController : ApiController
     {
-        private readonly ProviderOrchestrator _providerOrchestrator;
+        private readonly IProviderOrchestrator _providerOrchestrator;
 
-        private readonly ApprenticeshipsOrchestrator _apprenticeshipsOrchestrator;
+        private readonly IApprenticeshipsOrchestrator _apprenticeshipsOrchestrator;
 
-        public ProviderController(ProviderOrchestrator providerOrchestrator, ApprenticeshipsOrchestrator apprenticeshipsOrchestrator)
+        public ProviderController(IProviderOrchestrator providerOrchestrator, IApprenticeshipsOrchestrator apprenticeshipsOrchestrator)
         {
             if (providerOrchestrator == null)
                 throw new ArgumentNullException(nameof(providerOrchestrator));
@@ -37,9 +37,7 @@ namespace SFA.DAS.Commitments.Api.Controllers
         {
             var response = await _providerOrchestrator.GetCommitments(providerId);
 
-            var commitments = response;
-
-            return Ok(commitments);
+            return Ok(response);
         }
 
         [Route("{providerId}/commitments/{commitmentId}", Name = "GetCommitmentForProvider")]
@@ -48,14 +46,12 @@ namespace SFA.DAS.Commitments.Api.Controllers
         {
             var response = await _providerOrchestrator.GetCommitment(providerId, commitmentId);
 
-            var commitment = response;
-
-            if (commitment == null)
+            if (response == null)
             {
                 return NotFound();
             }
 
-            return Ok(commitment);
+            return Ok(response);
         }
 
         [Route("{providerId}/apprenticeships")]
@@ -82,14 +78,12 @@ namespace SFA.DAS.Commitments.Api.Controllers
         {
             var response = await _providerOrchestrator.GetApprenticeship(providerId, apprenticeshipId);
 
-            var apprenticeship = response;
-
-            if (apprenticeship == null)
+            if (response == null)
             {
                 return NotFound();
             }
 
-            return Ok(apprenticeship);
+            return Ok(response);
         }
 
 

--- a/src/SFA.DAS.Commitments.Api/Orchestrators/ApprenticeshipOrchestrator.cs
+++ b/src/SFA.DAS.Commitments.Api/Orchestrators/ApprenticeshipOrchestrator.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using MediatR;
@@ -21,7 +20,7 @@ using SFA.DAS.Commitments.Domain.Entities.DataLock;
 
 namespace SFA.DAS.Commitments.Api.Orchestrators
 {
-    public class ApprenticeshipsOrchestrator
+    public class ApprenticeshipsOrchestrator : IApprenticeshipsOrchestrator
     {
         private readonly IMediator _mediator;
         private readonly IDataLockMapper _dataLockMapper;
@@ -114,7 +113,7 @@ namespace SFA.DAS.Commitments.Api.Orchestrators
 
         public async Task TriageDataLocks(long apprenticeshipId, DataLockTriageSubmission triageSubmission, Caller caller)
         {
-            _logger.Trace($"Updating all data locks to triange status: {triageSubmission.TriageStatus}, for apprenticeship: {apprenticeshipId}", apprenticeshipId: apprenticeshipId, caller: caller);
+            _logger.Trace($"Updating all data locks to triage status: {triageSubmission.TriageStatus}, for apprenticeship: {apprenticeshipId}", apprenticeshipId: apprenticeshipId, caller: caller);
 
             await _mediator.SendAsync(new TriageDataLocksCommand
             {
@@ -123,7 +122,7 @@ namespace SFA.DAS.Commitments.Api.Orchestrators
                 UserId = triageSubmission.UserId
             });
 
-            _logger.Info($"Updated all data locks to triange status: {triageSubmission.TriageStatus}, for apprenticeship: {apprenticeshipId}", apprenticeshipId: apprenticeshipId, caller: caller);
+            _logger.Info($"Updated all data locks to triage status: {triageSubmission.TriageStatus}, for apprenticeship: {apprenticeshipId}", apprenticeshipId: apprenticeshipId, caller: caller);
         }
 
         public async Task ResolveDataLock(long apprenticeshipId, DataLocksTriageResolutionSubmission triageSubmission, Caller caller)

--- a/src/SFA.DAS.Commitments.Api/Orchestrators/EmployerOrchestrator.cs
+++ b/src/SFA.DAS.Commitments.Api/Orchestrators/EmployerOrchestrator.cs
@@ -41,7 +41,7 @@ using Relationship = SFA.DAS.Commitments.Domain.Entities.Relationship;
 
 namespace SFA.DAS.Commitments.Api.Orchestrators
 {
-    public class EmployerOrchestrator
+    public class EmployerOrchestrator : IEmployerOrchestrator
     {
         private readonly IMediator _mediator;
         private readonly ICommitmentsLogger _logger;
@@ -220,7 +220,7 @@ namespace SFA.DAS.Commitments.Api.Orchestrators
             };
         }
 
-        public async Task<Api.Types.Apprenticeship.Apprenticeship> GetApprenticeship(long accountId, long apprenticeshipId)
+        public async Task<Apprenticeship.Apprenticeship> GetApprenticeship(long accountId, long apprenticeshipId)
         {
             _logger.Trace($"Getting apprenticeship {apprenticeshipId} for employer account {accountId}", accountId: accountId, apprenticeshipId: apprenticeshipId);
 
@@ -303,7 +303,7 @@ namespace SFA.DAS.Commitments.Api.Orchestrators
             _logger.Info($"Updated Provider Payment Priorities with {submission.Priorities.Count} providers for employer account {accountId}", accountId);
         }
 
-        public async Task<IEnumerable<Types.ProviderPayment.ProviderPaymentPriorityItem>> GetCustomProviderPaymentPriority(long accountId)
+        public async Task<IEnumerable<ProviderPaymentPriorityItem>> GetCustomProviderPaymentPriority(long accountId)
         {
             _logger.Trace($"Getting Provider Payment Priority for employer account {accountId}", accountId);
 
@@ -445,7 +445,7 @@ namespace SFA.DAS.Commitments.Api.Orchestrators
             _logger.Info($"Deleted commitment {commitmentId} for employer account {accountId}", accountId: accountId, commitmentId: commitmentId);
         }
 
-        public async Task<Types.Apprenticeship.ApprenticeshipUpdate> GetPendingApprenticeshipUpdate(long accountId, long apprenticeshipId)
+        public async Task<Apprenticeship.ApprenticeshipUpdate> GetPendingApprenticeshipUpdate(long accountId, long apprenticeshipId)
         {
             _logger.Trace($"Getting pending update for apprenticeship {apprenticeshipId} for employer account {accountId}", accountId, apprenticeshipId: apprenticeshipId );
 

--- a/src/SFA.DAS.Commitments.Api/Orchestrators/IApprenticeshipsOrchestrator.cs
+++ b/src/SFA.DAS.Commitments.Api/Orchestrators/IApprenticeshipsOrchestrator.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using SFA.DAS.Commitments.Api.Types.DataLock;
+using SFA.DAS.Commitments.Domain;
+
+namespace SFA.DAS.Commitments.Api.Orchestrators
+{
+    public interface IApprenticeshipsOrchestrator
+    {
+        Task<Types.DataLock.DataLockStatus> GetDataLock(long apprenticeshipId, long dataLockEventId);
+        Task<IEnumerable<Types.DataLock.DataLockStatus>> GetDataLocks(long apprenticeshipId, Caller caller);
+        Task<DataLockSummary> GetDataLockSummary(long apprenticeshipId, Caller caller);
+        Task TriageDataLock(long apprenticeshipId, long dataLockEventId, DataLockTriageSubmission triageSubmission, Caller caller);
+        Task TriageDataLocks(long apprenticeshipId, DataLockTriageSubmission triageSubmission, Caller caller);
+        Task ResolveDataLock(long apprenticeshipId, DataLocksTriageResolutionSubmission triageSubmission, Caller caller);
+        Task<IEnumerable<Types.Apprenticeship.PriceHistory>> GetPriceHistory(long apprenticeshipId, Caller caller);
+    }
+}

--- a/src/SFA.DAS.Commitments.Api/Orchestrators/IEmployerOrchestrator.cs
+++ b/src/SFA.DAS.Commitments.Api/Orchestrators/IEmployerOrchestrator.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using SFA.DAS.Commitments.Api.Types;
+using SFA.DAS.Commitments.Api.Types.ProviderPayment;
+
+namespace SFA.DAS.Commitments.Api.Orchestrators
+{
+    public interface IEmployerOrchestrator
+    {
+        Task<IEnumerable<Types.Commitment.CommitmentListItem>> GetCommitments(long accountId);
+        Task<Types.Commitment.CommitmentView> GetCommitment(long accountId, long commitmentId);
+        Task<long> CreateCommitment(long accountId, Types.Commitment.CommitmentRequest commitmentRequest);
+        Task<IEnumerable<Types.Apprenticeship.Apprenticeship>> GetApprenticeships(long accountId);
+        Task<Types.Apprenticeship.ApprenticeshipSearchResponse> GetApprenticeships(long accountId, Types.Apprenticeship.ApprenticeshipSearchQuery query);
+        Task<Types.Apprenticeship.Apprenticeship> GetApprenticeship(long accountId, long apprenticeshipId);
+        Task<long> CreateApprenticeship(long accountId, long commitmentId, Types.Apprenticeship.ApprenticeshipRequest apprenticeshipRequest);
+        Task PutApprenticeship(long accountId, long commitmentId, long apprenticeshipId, Types.Apprenticeship.ApprenticeshipRequest apprenticeshipRequest);
+        Task UpdateCustomProviderPaymentPriority(long accountId, ProviderPaymentPrioritySubmission submission);
+        Task<IEnumerable<ProviderPaymentPriorityItem>> GetCustomProviderPaymentPriority(long accountId);
+        Task PatchCommitment(long accountId, long commitmentId, CommitmentSubmission submission);
+        Task PatchApprenticeship(long accountId, long apprenticeshipId, Types.Apprenticeship.ApprenticeshipSubmission apprenticeshipSubmission);
+        Task DeleteApprenticeship(long accountId, long apprenticeshipId, string userId, string userName);
+        Task DeleteCommitment(long accountId, long commitmentId, string userId, string userName);
+        Task<Types.Apprenticeship.ApprenticeshipUpdate> GetPendingApprenticeshipUpdate(long accountId, long apprenticeshipId);
+        Task CreateApprenticeshipUpdate(long accountId, Types.Apprenticeship.ApprenticeshipUpdateRequest updateRequest);
+        Task PatchApprenticeshipUpdate(long accountId, long apprenticeshipId, Types.Apprenticeship.ApprenticeshipUpdateSubmission submission);
+        Task<IEnumerable<Types.ApprenticeshipStatusSummary>> GetAccountSummary(long accountId);
+    }
+}

--- a/src/SFA.DAS.Commitments.Api/Orchestrators/IProviderOrchestrator.cs
+++ b/src/SFA.DAS.Commitments.Api/Orchestrators/IProviderOrchestrator.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using SFA.DAS.Commitments.Api.Types;
+using SFA.DAS.Commitments.Api.Types.Apprenticeship;
+using SFA.DAS.Commitments.Api.Types.Commitment;
+
+namespace SFA.DAS.Commitments.Api.Orchestrators
+{
+    public interface IProviderOrchestrator
+    {
+        Task<IEnumerable<CommitmentListItem>> GetCommitments(long providerId);
+        Task<CommitmentView> GetCommitment(long providerId, long commitmentId);
+        Task<IEnumerable<Apprenticeship>> GetApprenticeships(long providerId);
+        Task<ApprenticeshipSearchResponse> GetApprenticeships(long providerId, ApprenticeshipSearchQuery query);
+        Task<Apprenticeship> GetApprenticeship(long providerId, long apprenticeshipId);
+        Task<long> CreateApprenticeship(long providerId, long commitmentId, ApprenticeshipRequest apprenticeshipRequest);
+        Task PutApprenticeship(long providerId, long commitmentId, long apprenticeshipId, ApprenticeshipRequest apprenticeshipRequest);
+        Task CreateApprenticeships(long providerId, long commitmentId, BulkApprenticeshipRequest bulkRequest);
+        Task PatchCommitment(long providerId, long commitmentId, CommitmentSubmission submission);
+        Task DeleteApprenticeship(long providerId, long apprenticeshipId, string userId, string userName);
+        Task DeleteCommitment(long providerId, long commitmentId, string userId, string userName);
+        Task<Types.Relationship> GetRelationship(long providerId, long employerAccountId, string legalEntityId);
+        Task<Types.Relationship> GetRelationship(long providerId, long commitmentId);
+        Task PatchRelationship(long providerId, long employerAccountId, string legalEntityId, RelationshipRequest patchRequest);
+        Task<Types.Apprenticeship.ApprenticeshipUpdate> GetPendingApprenticeshipUpdate(long providerId, long apprenticeshipId);
+        Task CreateApprenticeshipUpdate(long providerId, ApprenticeshipUpdateRequest updateRequest);
+        Task PatchApprenticeshipUpdate(long providerId, long apprenticeshipId, ApprenticeshipUpdateSubmission submission);
+        Task<long> PostBulkUploadFile(long providerId, BulkUploadFileRequest bulkUploadFile);
+        Task<string> GetBulkUploadFile(long providerId, long bulkUploadFileId);
+    }
+}

--- a/src/SFA.DAS.Commitments.Api/Orchestrators/Mappers/CommitmentMapper.cs
+++ b/src/SFA.DAS.Commitments.Api/Orchestrators/Mappers/CommitmentMapper.cs
@@ -68,24 +68,26 @@ namespace SFA.DAS.Commitments.Api.Orchestrators.Mappers
 
         public CommitmentView MapFrom(Commitment commitment, CallerType callerType)
         {
-            return new CommitmentView
-            {
-                Id = commitment.Id,
-                Reference = commitment.Reference,
-                ProviderId = commitment.ProviderId,
-                ProviderName = commitment.ProviderName,
-                EmployerAccountId = commitment.EmployerAccountId,
-                LegalEntityId = commitment.LegalEntityId,
-                LegalEntityName = commitment.LegalEntityName,
-                EditStatus = (Types.Commitment.Types.EditStatus)commitment.EditStatus,
-                AgreementStatus = (AgreementStatus)_commitmentRules.DetermineAgreementStatus(commitment.Apprenticeships),
-                LastAction = (Types.Commitment.Types.LastAction)commitment.LastAction,
-                CanBeApproved = callerType == CallerType.Employer ? commitment.EmployerCanApproveCommitment : commitment.ProviderCanApproveCommitment,
-                EmployerLastUpdateInfo = new LastUpdateInfo { Name = commitment.LastUpdatedByEmployerName, EmailAddress = commitment.LastUpdatedByEmployerEmail },
-                ProviderLastUpdateInfo = new LastUpdateInfo { Name = commitment.LastUpdatedByProviderName, EmailAddress = commitment.LastUpdatedByProviderEmail },
-                Apprenticeships = MapApprenticeshipsFrom(commitment.Apprenticeships, callerType),
-                Messages = MapMessagesFrom(commitment.Messages)
-            };
+            return commitment == null
+                ? null
+                : new CommitmentView
+                {
+                    Id = commitment.Id,
+                    Reference = commitment.Reference,
+                    ProviderId = commitment.ProviderId,
+                    ProviderName = commitment.ProviderName,
+                    EmployerAccountId = commitment.EmployerAccountId,
+                    LegalEntityId = commitment.LegalEntityId,
+                    LegalEntityName = commitment.LegalEntityName,
+                    EditStatus = (Types.Commitment.Types.EditStatus) commitment.EditStatus,
+                    AgreementStatus = (AgreementStatus) _commitmentRules.DetermineAgreementStatus(commitment.Apprenticeships),
+                    LastAction = (Types.Commitment.Types.LastAction) commitment.LastAction,
+                    CanBeApproved = callerType == CallerType.Employer ? commitment.EmployerCanApproveCommitment : commitment.ProviderCanApproveCommitment,
+                    EmployerLastUpdateInfo = new LastUpdateInfo {Name = commitment.LastUpdatedByEmployerName, EmailAddress = commitment.LastUpdatedByEmployerEmail},
+                    ProviderLastUpdateInfo = new LastUpdateInfo {Name = commitment.LastUpdatedByProviderName, EmailAddress = commitment.LastUpdatedByProviderEmail},
+                    Apprenticeships = MapApprenticeshipsFrom(commitment.Apprenticeships, callerType),
+                    Messages = MapMessagesFrom(commitment.Messages)
+                };
         }
 
         public Commitment MapFrom(Types.Commitment.Commitment commitment)

--- a/src/SFA.DAS.Commitments.Api/Orchestrators/ProviderOrchestrator.cs
+++ b/src/SFA.DAS.Commitments.Api/Orchestrators/ProviderOrchestrator.cs
@@ -42,7 +42,7 @@ using Relationship = SFA.DAS.Commitments.Domain.Entities.Relationship;
 
 namespace SFA.DAS.Commitments.Api.Orchestrators
 {
-    public class ProviderOrchestrator
+    public class ProviderOrchestrator : IProviderOrchestrator
     {
         private readonly IMediator _mediator;
         private readonly ICommitmentsLogger _logger;
@@ -147,7 +147,7 @@ namespace SFA.DAS.Commitments.Api.Orchestrators
                 Caller = new Caller
                 {
                     CallerType = CallerType.Provider,
-                    Id = providerId,
+                    Id = providerId
                 }
             });
 
@@ -262,7 +262,7 @@ namespace SFA.DAS.Commitments.Api.Orchestrators
                 UserName = bulkRequest.LastUpdatedByInfo?.Name
             });
 
-            _logger.Info($"Bulk uploaded {bulkRequest.Apprenticeships?.Count ?? 0} apprenticeships for commitment {commitmentId} for provider {providerId}", providerId: providerId, commitmentId: commitmentId, recordCount: bulkRequest.Apprenticeships?.Count ?? 0);
+            _logger.Info($"Bulk uploaded {bulkRequest.Apprenticeships?.Count} apprenticeships for commitment {commitmentId} for provider {providerId}", providerId: providerId, commitmentId: commitmentId, recordCount: bulkRequest.Apprenticeships?.Count);
 
         }
 
@@ -504,7 +504,7 @@ namespace SFA.DAS.Commitments.Api.Orchestrators
                 LegalEntityOrganisationType = (OrganisationType)entity.LegalEntityOrganisationType,
                 ProviderId = entity.ProviderId,
                 ProviderName = entity.ProviderName,
-                Verified = entity.Verified,
+                Verified = entity.Verified
             };
         }
     }

--- a/src/SFA.DAS.Commitments.Api/SFA.DAS.Commitments.Api.csproj
+++ b/src/SFA.DAS.Commitments.Api/SFA.DAS.Commitments.Api.csproj
@@ -156,7 +156,7 @@
     </Reference>
     <Reference Include="SFA.DAS.Configuration, Version=1.0.0.43116, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Configuration.1.0.0.43116\lib\net45\SFA.DAS.Configuration.dll</HintPath>
-	</Reference>
+    </Reference>
     <Reference Include="SFA.DAS.Common.Domain, Version=1.3.0.44308, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Common.Domain.1.3.0.44308\lib\net45\SFA.DAS.Common.Domain.dll</HintPath>
     </Reference>
@@ -326,6 +326,9 @@
     <Compile Include="Models\SystemDetails.cs" />
     <Compile Include="Orchestrators\ApprenticeshipOrchestrator.cs" />
     <Compile Include="Orchestrators\EmployerOrchestrator.cs" />
+    <Compile Include="Orchestrators\IApprenticeshipsOrchestrator.cs" />
+    <Compile Include="Orchestrators\IEmployerOrchestrator.cs" />
+    <Compile Include="Orchestrators\IProviderOrchestrator.cs" />
     <Compile Include="Orchestrators\Mappers\ApprenticeshipFilterService.cs" />
     <Compile Include="Orchestrators\Mappers\ApprenticeshipMapper.cs" />
     <Compile Include="Orchestrators\Mappers\CommitmentMapper.cs" />


### PR DESCRIPTION
…bly happen if the stored proc GetCommitment doesn't return anything, then the method will throw. As the ProviderController and EmployerController both handle empty responses from their Orchestrators, have added a null check for that and return null if it is null. Updated the orchestrators to have interfaces to make the unit testing of the controller methods simpler