### PR TITLE
Dpp 1258 fix history

### DIFF
--- a/src/SFA.DAS.Commitments.Application/Commands/TransferApproval/TransferApprovalCommandHandler.cs
+++ b/src/SFA.DAS.Commitments.Application/Commands/TransferApproval/TransferApprovalCommandHandler.cs
@@ -67,9 +67,9 @@ namespace SFA.DAS.Commitments.Application.Commands.TransferApproval
             if (command.TransferApprovalStatus == TransferApprovalStatus.TransferApproved)
             {
                 // Unfortunately we need to keep the commitment object explicitly updated as the HistoryService keeps a reference to the orginal object 
-                // This problem can be resolved in c# 7.0 using new local ref eg 'ref commitment = ref await .....' syntax to re-get the updated commitment object
+                // This problem may be resolved in c# 7.0 using new local ref eg 'ref commitment = ref await .....' syntax to re-get the updated commitment object
                 // but the behaviour of the HistoryItem object may be problematic as it's making assumptions of how updates will occur
-                await UpdateCommitmentObjectWithNewValues(command, commitment);
+                await UpdateCommitmentObjectWithNewValues(commitment);
 
                 await Task.WhenAll(
                     _cohortApprovalService.UpdateApprenticeshipsPaymentStatusToPaid(commitment),
@@ -83,9 +83,9 @@ namespace SFA.DAS.Commitments.Application.Commands.TransferApproval
 
         }
 
-        private async Task UpdateCommitmentObjectWithNewValues(TransferApprovalCommand command, Commitment commitment)
+        private async Task UpdateCommitmentObjectWithNewValues(Commitment commitment)
         {
-            var updatedCommitment = await _commitmentRepository.GetCommitmentById(command.CommitmentId);
+            var updatedCommitment = await _commitmentRepository.GetCommitmentById(commitment.Id);
             commitment.TransferApprovalStatus = updatedCommitment.TransferApprovalStatus;
             commitment.TransferApprovalActionedByEmployerEmail = updatedCommitment.TransferApprovalActionedByEmployerEmail;
             commitment.TransferApprovalActionedByEmployerName = updatedCommitment.TransferApprovalActionedByEmployerName;

--- a/src/SFA.DAS.Commitments.Application/Commands/TransferApproval/TransferApprovalCommandHandler.cs
+++ b/src/SFA.DAS.Commitments.Application/Commands/TransferApproval/TransferApprovalCommandHandler.cs
@@ -59,23 +59,37 @@ namespace SFA.DAS.Commitments.Application.Commands.TransferApproval
             CheckAuthorization(command, commitment);
             CheckCommitmentStatus(commitment, command);
 
+            _historyService.TrackUpdate(commitment, CommitmentChangeType.TransferSenderApproval.ToString(), commitment.Id, null, CallerType.TransferSender, command.UserEmail, commitment.ProviderId, command.TransferSenderId, command.UserName);
+
             await _commitmentRepository.SetTransferApproval(command.CommitmentId, command.TransferApprovalStatus,
                 command.UserEmail, command.UserName);
 
             if (command.TransferApprovalStatus == TransferApprovalStatus.TransferApproved)
             {
-                commitment.TransferApprovalStatus = TransferApprovalStatus.TransferApproved;
+                // Unfortunately we need to keep the commitment object explicitly updated as the HistoryService keeps a reference to the orginal object 
+                // This problem can be resolved in c# 7.0 using new local ref eg 'ref commitment = ref await .....' syntax to re-get the updated commitment object
+                // but the behaviour of the HistoryItem object may be problematic as it's making assumptions of how updates will occur
+                await UpdateCommitmentObjectWithNewValues(command, commitment);
+
                 await Task.WhenAll(
                     _cohortApprovalService.UpdateApprenticeshipsPaymentStatusToPaid(commitment),
                     _cohortApprovalService.CreatePriceHistory(commitment),
                     _cohortApprovalService.PublishApprenticeshipEventsWhenTransferSenderHasApproved(commitment),
-                    _cohortApprovalService.ReorderPayments(commitment.EmployerAccountId));
-                _historyService.TrackUpdate(commitment, CommitmentChangeType.TransferSenderApproval.ToString(), commitment.Id, null, CallerType.TransferSender, command.UserEmail, commitment.ProviderId, command.TransferSenderId, command.UserName);
-                await _historyService.Save();
+                    _cohortApprovalService.ReorderPayments(commitment.EmployerAccountId),
+                    _historyService.Save());
             }
 
             await PublishApprovedOrRejectedMessage(command);
 
+        }
+
+        private async Task UpdateCommitmentObjectWithNewValues(TransferApprovalCommand command, Commitment commitment)
+        {
+            var updatedCommitment = await _commitmentRepository.GetCommitmentById(command.CommitmentId);
+            commitment.TransferApprovalStatus = updatedCommitment.TransferApprovalStatus;
+            commitment.TransferApprovalActionedByEmployerEmail = updatedCommitment.TransferApprovalActionedByEmployerEmail;
+            commitment.TransferApprovalActionedByEmployerName = updatedCommitment.TransferApprovalActionedByEmployerName;
+            commitment.TransferApprovalActionedOn = updatedCommitment.TransferApprovalActionedOn;
         }
 
         private static void CheckAuthorization(TransferApprovalCommand message, Commitment commitment)


### PR DESCRIPTION
This is a fix to deal with the history not being added correctly. The tracking object is not changed by the SP call. And we need to set the properties manually so the change becomes visible. 

This problem goes away with c# 7.0 (because we can use the (ref commitment = ref GetComm....)
