### PR TITLE
DPP-1292 Prevent A Multiple Uln Instance When Transfer Request Pending With Sender

### DIFF
--- a/src/SFA.DAS.Commitments.Api.IntegrationTests/DatabaseSetup/CommitmentsDatabase.cs
+++ b/src/SFA.DAS.Commitments.Api.IntegrationTests/DatabaseSetup/CommitmentsDatabase.cs
@@ -13,7 +13,7 @@ namespace SFA.DAS.Commitments.Api.IntegrationTests.DatabaseSetup
         // need to update when the data needs to be regenerated,
         // either because the schema of the test data tables changes
         // or when have added a new integration test that injects data
-        public static readonly int? SchemaVersion = 2;
+        public static readonly int? SchemaVersion = 3;
 
         public const string ApprenticeshipTableName = "[dbo].[Apprenticeship]";
         public const string ApprenticeshipUpdateTableName = "[dbo].[ApprenticeshipUpdate]";

--- a/src/SFA.DAS.Commitments.Api.IntegrationTests/DatabaseSetup/TestData.cs
+++ b/src/SFA.DAS.Commitments.Api.IntegrationTests/DatabaseSetup/TestData.cs
@@ -3,6 +3,7 @@ using SFA.DAS.Commitments.Api.IntegrationTests.DatabaseSetup.Generators;
 using SFA.DAS.Commitments.Api.IntegrationTests.Helpers;
 using SFA.DAS.Commitments.Api.IntegrationTests.Tests.API.GetApprenticeship;
 using SFA.DAS.Commitments.Api.IntegrationTests.Tests.API.GetApprenticeships;
+using SFA.DAS.Commitments.Api.IntegrationTests.Tests.API.ValidateOverlappingApprenticeships;
 using SFA.DAS.Commitments.Infrastructure.Configuration;
 
 namespace SFA.DAS.Commitments.Api.IntegrationTests.DatabaseSetup
@@ -110,6 +111,7 @@ namespace SFA.DAS.Commitments.Api.IntegrationTests.DatabaseSetup
             // *** add your call to inject the specific data your integration test needs here ***
             WhenGettingEmployerApprenticeshipCost.InjectTestSpecificData(testDataInjector);
             WhenGettingEmployerApprenticeships.InjectTestSpecificData(testDataInjector);
+            WhenValidatingOverlappingApprenticeships.InjectTestSpecificData(testDataInjector);
         }
     }
 }

--- a/src/SFA.DAS.Commitments.Api.IntegrationTests/SFA.DAS.Commitments.Api.IntegrationTests.csproj
+++ b/src/SFA.DAS.Commitments.Api.IntegrationTests/SFA.DAS.Commitments.Api.IntegrationTests.csproj
@@ -347,6 +347,7 @@
     <Compile Include="Tests\API\GetApprenticeship\WhenGettingEmployerApprenticeshipCost.cs" />
     <Compile Include="Tests\API\GetApprenticeships\WhenGettingEmployerApprenticeships.cs" />
     <Compile Include="Tests\API\GetCommitments\GetCommitments.cs" />
+    <Compile Include="Tests\API\ValidateOverlappingApprenticeships\WhenValidatingOverlappingApprenticeships.cs" />
     <Compile Include="Tests\Scenarios\WhenSimulatingRealWorldApprenticeshipLoad.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SFA.DAS.Commitments.Api.IntegrationTests/Tests/API/ValidateOverlappingApprenticeships/WhenValidatingOverlappingApprenticeships.cs
+++ b/src/SFA.DAS.Commitments.Api.IntegrationTests/Tests/API/ValidateOverlappingApprenticeships/WhenValidatingOverlappingApprenticeships.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using SFA.DAS.Commitments.Api.IntegrationTests.ApiHost;
+using SFA.DAS.Commitments.Api.IntegrationTests.DatabaseSetup;
+using SFA.DAS.Commitments.Api.IntegrationTests.Helpers;
+using SFA.DAS.Commitments.Api.Types;
+using SFA.DAS.Commitments.Api.Types.Apprenticeship.Types;
+using SFA.DAS.Commitments.Api.Types.Validation;
+using SFA.DAS.Commitments.Api.Types.Validation.Types;
+
+namespace SFA.DAS.Commitments.Api.IntegrationTests.Tests.API.ValidateOverlappingApprenticeships
+{
+    [TestFixture]
+    public class WhenValidatingOverlappingApprenticeships
+    {
+        private const string FirstName = "ValidateOverlappingApprenticeships";
+        private const string LastName = "ThenApprenticeshipWaitingForSenderApprovalIsIncludedInCheck";
+
+        private const string Uln = "1773673121";
+
+        public static void InjectTestSpecificData(TestDataInjector injector)
+        {
+            var apprenticeship = TestEntities.GetDbSetupApprenticeship(
+                injector.AddCommitment(TestEntities.GetDbSetupCommitment()), FirstName, LastName);
+
+            apprenticeship.ULN = Uln;
+            apprenticeship.AgreementStatus = AgreementStatus.BothAgreed;
+            apprenticeship.PaymentStatus = PaymentStatus.PendingApproval;
+            apprenticeship.StartDate = new DateTime(2010, 1, 1);
+            apprenticeship.EndDate = new DateTime(2011, 1, 1);
+
+            injector.AddApprenticeship(apprenticeship);
+        }
+
+        [Test]
+        public async Task ThenApprenticeshipWaitingForSenderApprovalIsIncludedInCheck()
+        {
+            const string url = "api/validation/apprenticeships/overlapping";
+
+            var request = new List<ApprenticeshipOverlapValidationRequest>
+            {
+                new ApprenticeshipOverlapValidationRequest
+                {
+                    ApprenticeshipId = 54321L,
+                    Uln = Uln,
+                    StartDate = new DateTime(2010, 6, 1),
+                    EndDate = new DateTime(2011, 6, 1)
+                }
+            };
+
+            var stopwatch = Stopwatch.StartNew();
+            // block on result, rather than awaiting as it gives a more realistic timing
+            var result = IntegrationTestServer.Client.PostAsJsonAsync(url, request).Result;
+            await TestLog.Progress($"Call to ValidateOverlappingApprenticeships took {stopwatch.Elapsed}");
+
+            Assert.IsTrue(result.IsSuccessStatusCode);
+
+            var resultsAsString = await result.Content.ReadAsStringAsync();
+            var results = JsonConvert.DeserializeObject<IEnumerable<ApprenticeshipOverlapValidationResult>>(resultsAsString);
+
+            Assert.AreEqual(1, results.Count());
+
+            var firstValidationResult = results.First();
+            Assert.IsNotNull(firstValidationResult.OverlappingApprenticeships);
+            Assert.AreEqual(1, firstValidationResult.OverlappingApprenticeships.Count());
+
+            var firstOverlap = firstValidationResult.OverlappingApprenticeships.First();
+            // first check we have the correct apprenticeship
+            Assert.AreEqual($"{FirstName} {LastName}", firstOverlap.Apprenticeship.ApprenticeshipName);
+            Assert.AreEqual(ValidationFailReason.OverlappingStartDate, firstOverlap.ValidationFailReason);
+        }
+    }
+}

--- a/src/SFA.DAS.Commitments.Database/StoredProcedures/GetActiveApprenticeshipsByULNs.sql
+++ b/src/SFA.DAS.Commitments.Database/StoredProcedures/GetActiveApprenticeshipsByULNs.sql
@@ -1,4 +1,6 @@
-﻿CREATE PROCEDURE [dbo].[GetActiveApprenticeshipsByULNs]
+﻿-- gets all appenticeships that have been approved by employer and provider (unless subsequently completed or deleted)
+-- if transfer funded, we still return apprenticeships that haven't been approved by the sender yet
+CREATE PROCEDURE [dbo].[GetActiveApprenticeshipsByULNs]
 (
 	@ULNs [ULNTable] READONLY
 )
@@ -18,5 +20,6 @@ INNER JOIN [dbo].[Apprenticeship] a ON u.ULN = a.ULN
 INNER JOIN [dbo].[Commitment] c ON c.Id = a.CommitmentId
 WHERE
 a.AgreementStatus = 3 -- Both parties agreed - "right of the line"
-AND a.PaymentStatus IN (1,2,3) --Active, Paused or Cancelled
+AND a.PaymentStatus <= 3 --PendingApproval, Active, Paused or Cancelled
+-- (allowing PaymentStatus == 0 (PendingApproval) && AgreementStatus == 3, we catch transfer apprenticeships that have been approved by the receiver and provider, but not yet by the sender)
 END

--- a/src/SFA.DAS.Commitments.Database/StoredProcedures/GetActiveApprenticeshipsByULNs.sql
+++ b/src/SFA.DAS.Commitments.Database/StoredProcedures/GetActiveApprenticeshipsByULNs.sql
@@ -20,6 +20,6 @@ INNER JOIN [dbo].[Apprenticeship] a ON u.ULN = a.ULN
 INNER JOIN [dbo].[Commitment] c ON c.Id = a.CommitmentId
 WHERE
 a.AgreementStatus = 3 -- Both parties agreed - "right of the line"
-AND a.PaymentStatus <= 3 --PendingApproval, Active, Paused or Cancelled
+AND a.PaymentStatus <= 4 -- PendingApproval, Active, Paused, Withdrawn or Completed
 -- (allowing PaymentStatus == 0 (PendingApproval) && AgreementStatus == 3, we catch transfer apprenticeships that have been approved by the receiver and provider, but not yet by the sender)
 END


### PR DESCRIPTION
https://skillsfundingagency.atlassian.net/browse/DPP-1292

Include apprenticeships that are transfer funded and sitting waiting for approval by the sender when checking for apprenticeship overlaps.
Add integration test coverage for change.