### PR TITLE
Rename Task request subscriptions from MA to Task to reflect consumer

### DIFF
--- a/src/AzureTopicConfigurationStrucuture.json
+++ b/src/AzureTopicConfigurationStrucuture.json
@@ -25,15 +25,15 @@
   },
   {
     "topicName": "cohort_approval_by_transfer_sender_requested",
-    "subscription": [ "MA_CohortApprovalByTransferSenderRequested" ]
+    "subscription": [ "Task_CohortApprovalByTransferSenderRequested" ]
   },
   {
     "topicName": "cohort_approved_by_transfer_sender",
-    "subscription": [ "MA_CohortApprovedByTransferSender" ]
+    "subscription": [ "Task_CohortApprovedByTransferSender" ]
   },
   {
     "topicName": "cohort_rejected_by_transfer_sender",
-    "subscription": [ "MA_CohortRejectedByTransferSender" ]
+    "subscription": [ "Task_CohortRejectedByTransferSender" ]
   },
   {
     "topicName": "cohort_created",


### PR DESCRIPTION
The subscription is for tasks rather than ma, so have renamed them to match.