### PR TITLE
Corrects binding redirect for system.net.http

### DIFF
--- a/src/SFA.DAS.Commitments.Api/Web.config
+++ b/src/SFA.DAS.Commitments.Api/Web.config
@@ -173,7 +173,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.1.2" newVersion="4.1.1.2" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
This is a fix for the system.net.http issue that has been mentioned. However, there is no ticket for this so it needs renaming once a ticket is in place. The fix can be tested against this branch but should not be merged without being related to a ticket.