### PR TITLE
CV-50 Add overlap validation

### DIFF
--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2.UnitTests/Services/ApprenticeshipOverlapRulesTests.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2.UnitTests/Services/ApprenticeshipOverlapRulesTests.cs
@@ -1,0 +1,292 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using NUnit.Framework;
+using SFA.DAS.CommitmentsV2.Api.Types.Types;
+using SFA.DAS.CommitmentsV2.Models;
+using SFA.DAS.CommitmentsV2.Services;
+
+namespace SFA.DAS.CommitmentsV2.UnitTests.Services
+{
+    [TestFixture]
+    public class ApprenticeshipOverlapRulesTests
+    {
+        [TestCase("May-19 to Jul-19", "Jan-19 to Feb-19", OverlapStatus.None)]
+        [TestCase("May-19 to Jul-19", "Jan-19 to May-19", OverlapStatus.None)]
+        [TestCase("May-19 to Jul-19", "Jan-19 to Jun-19", OverlapStatus.OverlappingEndDate)]
+        [TestCase("May-19 to Jul-19", "May-19 to Jul-19", OverlapStatus.DateEmbrace)]
+        [TestCase("May-19 to Jul-19", "Jun-19 to Aug-19", OverlapStatus.OverlappingStartDate)]
+        [TestCase("May-19 to Jul-19", "Jul-19 to Aug-19", OverlapStatus.None)]
+        [TestCase("May-19 to Aug-19", "Jun-19 to Jul-19", OverlapStatus.DateWithin)]
+
+        public void SingleApprenticeship_WithExplicitStartAndEndDates_ShouldDetermineOverlapCorrectly(
+            string apprenticeshipStartEnd, 
+            string testStartEnd, 
+            OverlapStatus expectedOverlapStatus)
+        {
+            var apprenticeshipDates = apprenticeshipStartEnd.StartEndPeriod();
+
+            var fixtures = new ApprenticeshipOverlapRulesTestFixtures()
+                                .WithConfirmedApprenticeship("123", apprenticeshipDates.StartDate, apprenticeshipDates.EndDate);
+
+            var testDates = testStartEnd.StartEndPeriod();
+            fixtures.AssertApprenticeOverlapStatus(testDates.StartDate, testDates.EndDate, expectedOverlapStatus);
+        }
+
+        [TestCase("120, 120, 120", "May-19 to Jul-19, Jan-19 to Mar-19", "Feb-19 to Mar-19", OverlapStatus.OverlappingStartDate)]
+        [TestCase("121, 121, 121", "Jan-19 to Mar-19, May-19 to Jul-19", "Apr-19 to Jun-19", OverlapStatus.OverlappingEndDate)]
+        [TestCase("122, 122, 122", "Jan-19 to Mar-19, May-19 to Jul-19", "Feb-19 to Jun-19", OverlapStatus.OverlappingDates)]
+        [TestCase("123, 123, 123", "Feb-19 to Mar-19, May-19 to Jul-19", "Jan-19 to Jun-19", OverlapStatus.DateEmbrace | OverlapStatus.OverlappingEndDate)]
+        [TestCase("124, 124, 124", "Feb-19 to Mar-19, May-19 to Jul-19", "Jan-19 to Apr-19", OverlapStatus.DateEmbrace)]
+        [TestCase("124", "", "Jan-19 to Apr-19", OverlapStatus.None)]
+        public void MultipleApprenticeship_WithExplicitStartAndEndDates_ShouldDetermineOverlapCorrectly(
+            // first uln is for the test, the rest are for the existing apprenticeships
+            string ulns,
+            string apprenticeshipsStartEnd,
+            string testStartEnd,
+            OverlapStatus expectedOverlapStatus)
+        {
+            // arrange
+            var fixtures = new ApprenticeshipOverlapRulesTestFixtures();
+            var ulnStack = new Stack<string>(ulns.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()));
+
+            foreach (var apprenticeshipDates in apprenticeshipsStartEnd.StartEndPeriods())
+            {
+                fixtures.WithConfirmedApprenticeship(ulnStack.Pop(), apprenticeshipDates.StartDate, apprenticeshipDates.EndDate);
+            }
+
+            var testDates = testStartEnd.StartEndPeriod();
+
+            // act
+            var actualOverlapStatus = fixtures.DetermineOverlapStatus(ulnStack.Pop(), testDates.StartDate, testDates.EndDate);
+
+            // assert
+            Assert.AreEqual(expectedOverlapStatus, actualOverlapStatus);
+        }
+
+        [TestCase("May-19 to Jul-19, Jan-19 to Mar-19", "Feb-19 to Mar-19")]
+        [TestCase("Jan-19 to Mar-19, May-19 to Jul-19", "Apr-19 to Jun-19")]
+        [TestCase("Jan-19 to Mar-19, May-19 to Jul-19", "Feb-19 to Jun-19")]
+        [TestCase("Feb-19 to Mar-19, May-19 to Jul-19", "Jan-19 to Jun-19")]
+        [TestCase("Feb-19 to Mar-19, May-19 to Jul-19", "Jan-19 to Apr-19")]
+       public void MultipleApprenticeship_WithDifferenceUlns_ShouldNotDetectAsOverlaps(
+            string apprenticeshipsStartEnd,
+            string testStartEnd)
+        {
+            // arrange
+            var fixtures = new ApprenticeshipOverlapRulesTestFixtures();
+
+            foreach (var apprenticeshipDates in apprenticeshipsStartEnd.StartEndPeriods())
+            {
+                fixtures.WithConfirmedApprenticeship("999", apprenticeshipDates.StartDate, apprenticeshipDates.EndDate);
+            }
+
+            var testDates = testStartEnd.StartEndPeriod();
+
+            // act
+            var actualOverlapStatus = fixtures.DetermineOverlapStatus("123", testDates.StartDate, testDates.EndDate);
+
+            // assert
+            Assert.AreEqual(OverlapStatus.None, actualOverlapStatus);
+       }
+
+       [Test]
+       public void MultipleApprenticeship_WithCancelled_ShouldNotIncludeCancelledApprenticeshipsAfterStoppedDate()
+       {
+           const string uln = "123";
+
+           // arrange
+           var fixtures = new ApprenticeshipOverlapRulesTestFixtures()
+               .WithConfirmedApprenticeship(uln, new DateTime(2019, 01, 01), new DateTime(2019, 12, 31) )
+               .ThatHasCancelled(new DateTime(2019, 07, 01));
+
+           // act
+           var actualOverlapStatus = fixtures.DetermineOverlapStatus(uln, new DateTime(2019, 08, 01), new DateTime(2017, 09, 01) );
+
+           // assert
+           Assert.AreEqual(OverlapStatus.None, actualOverlapStatus);
+       }
+
+       [Test]
+       public void MultipleApprenticeship_WithCancelled_ShouldIncludeCancelledApprenticeshipsBeforeStoppedDate()
+       {
+           const string uln = "123";
+
+            // arrange
+            var fixtures = new ApprenticeshipOverlapRulesTestFixtures()
+               .WithConfirmedApprenticeship(uln, new DateTime(2019, 01, 01), new DateTime(2019, 12, 31))
+               .ThatHasCancelled(new DateTime(2019, 07, 01));
+
+           // act
+           var actualOverlapStatus = fixtures.DetermineOverlapStatus(uln, new DateTime(2019, 05, 01), new DateTime(2017, 06, 01));
+
+           // assert
+           Assert.AreEqual(OverlapStatus.OverlappingStartDate, actualOverlapStatus);
+       }
+
+        [TestCase("120, 120, 120", "May-19 to Jul-19, Jan-19 to Mar-19", "Feb-19 to Mar-19", true)]
+        [TestCase("121, 121, 121", "Jan-19 to Mar-19, May-19 to Jul-19", "Apr-19 to Jun-19", false)]
+        [TestCase("122, 122, 122", "Jan-19 to Mar-19, May-19 to Jul-19", "Feb-19 to Jun-19", true)]
+        [TestCase("123, 123, 123", "Feb-19 to Mar-19, May-19 to Jul-19", "Jan-19 to Jun-19", true)]
+        [TestCase("124, 124, 124", "Feb-19 to Mar-19, May-19 to Jul-19", "Jan-19 to Apr-19", true)]
+        public void MultipleApprenticeship_WithExplicitStartAndEndDates_ShouldIndicateProblemWithStartDateCorrectly(
+            // first uln is for the test, the rest are for the existing apprenticeships
+            string ulns,
+            string apprenticeshipsStartEnd,
+            string testStartEnd,
+            bool  expectProblemWithStartDate)
+        {
+            // arrange
+            var fixtures = new ApprenticeshipOverlapRulesTestFixtures();
+            var ulnStack = new Stack<string>(ulns.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()));
+
+            foreach (var apprenticeshipDates in apprenticeshipsStartEnd.StartEndPeriods())
+            {
+                fixtures.WithConfirmedApprenticeship(ulnStack.Pop(), apprenticeshipDates.StartDate, apprenticeshipDates.EndDate);
+            }
+
+            var testDates = testStartEnd.StartEndPeriod();
+
+            // act
+            var actualOverlapStatus = fixtures.DetermineOverlapStatus(ulnStack.Pop(), testDates.StartDate, testDates.EndDate);
+
+            // assert
+            fixtures.AssertStartDateIssueIsDetected(actualOverlapStatus, expectProblemWithStartDate);
+        }
+
+        [TestCase("120, 120, 120", "May-19 to Jul-19, Jan-19 to Mar-19", "Feb-19 to Mar-19", false)]
+        [TestCase("121, 121, 121", "Jan-19 to Mar-19, May-19 to Jul-19", "Apr-19 to Jun-19", true)]
+        [TestCase("122, 122, 122", "Jan-19 to Mar-19, May-19 to Jul-19", "Feb-19 to Jun-19", true)]
+        [TestCase("123, 123, 123", "Feb-19 to Mar-19, May-19 to Jul-19", "Jan-19 to Jun-19", true)]
+        [TestCase("124, 124, 124", "Feb-19 to Mar-19, May-19 to Jul-19", "Jan-19 to Apr-19", true)]
+        public void MultipleApprenticeship_WithExplicitStartAndEndDates_ShouldIndicateProblemWithEndDateCorrectly(
+            // first uln is for the test, the rest are for the existing apprenticeships
+            string ulns,
+            string apprenticeshipsStartEnd,
+            string testStartEnd,
+            bool expectProblemWithEndDate)
+        {
+
+            // arrange
+            var fixtures = new ApprenticeshipOverlapRulesTestFixtures();
+            var ulnStack = new Stack<string>(ulns.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()));
+
+            foreach (var apprenticeshipDates in apprenticeshipsStartEnd.StartEndPeriods())
+            {
+                fixtures.WithConfirmedApprenticeship(ulnStack.Pop(), apprenticeshipDates.StartDate, apprenticeshipDates.EndDate);
+            }
+
+            var testDates = testStartEnd.StartEndPeriod();
+
+            // act
+            var actualOverlapStatus = fixtures.DetermineOverlapStatus(ulnStack.Pop(), testDates.StartDate, testDates.EndDate);
+
+            // assert
+            fixtures.AssertEndDateIssueIsDetected(actualOverlapStatus, expectProblemWithEndDate);
+        }
+    }
+
+    public class ApprenticeshipOverlapRulesTestFixtures
+    {
+        private int _apprenticeshipId = 0;
+
+        public ApprenticeshipOverlapRulesTestFixtures()
+        {
+            Apprenticeships = new List<Apprenticeship>();
+        }
+
+        public List<Apprenticeship> Apprenticeships { get; }
+
+        public ApprenticeshipOverlapRulesTestFixtures WithDraftApprenticeship(string uln, DateTime? startDate, DateTime? endDate)
+        {
+            return AddApprenticeship(uln, startDate, endDate, PaymentStatus.PendingApproval);
+        }
+
+        public ApprenticeshipOverlapRulesTestFixtures WithConfirmedApprenticeship(string uln, DateTime startDate, DateTime endDate)
+        {
+            return AddApprenticeship(uln, startDate, endDate, PaymentStatus.Active);
+        }
+
+        public ApprenticeshipOverlapRulesTestFixtures ThatHasCancelled(DateTime stopDate)
+        {
+            var apprenticeship = Apprenticeships.Last();
+
+            apprenticeship.StopDate = stopDate;
+            apprenticeship.PaymentStatus = PaymentStatus.Withdrawn;
+
+            return this;
+        }
+
+        /// <summary>
+        ///     Verify that the added apprentice (only one apprentice should have been added) overlaps with the specified
+        ///     date period in the expected way. 
+        /// </summary>
+        public void AssertApprenticeOverlapStatus(DateTime startDate, DateTime endDate, OverlapStatus expectedOverlapStatus)
+        {
+            var apprenticeship = Apprenticeships.Single();
+
+            var actualOverlapStatus = apprenticeship.DetermineOverlap(startDate, endDate);
+
+            Assert.AreEqual(expectedOverlapStatus, actualOverlapStatus);
+        }
+
+        /// <summary>
+        ///     Verify that the start date has been correctly determined to have a problem. 
+        /// </summary>
+        public void AssertStartDateIssueIsDetected(OverlapStatus actualOverlapStatus, bool expectStartDateIssue)
+        {
+            AssertSpecifiedDateIssueIsDetected(actualOverlapStatus, OverlapStatus.ProblemWithStartDate, expectStartDateIssue);
+        }
+
+        /// <summary>
+        ///     Verify that the end date has been correctly determined to have a problem. 
+        /// </summary>
+        public void AssertEndDateIssueIsDetected(OverlapStatus actualOverlapStatus, bool expectEndDateIssue)
+        {
+            AssertSpecifiedDateIssueIsDetected(actualOverlapStatus, OverlapStatus.ProblemWithEndDate, expectEndDateIssue);
+        }
+
+        public OverlapStatus DetermineOverlapStatus(string uln, DateTime startDate, DateTime endDate)
+        {
+            var apprenticeshipWeWantToAdd = CreateApprenticeship(uln, startDate, endDate, PaymentStatus.Active);
+
+            var actualOverlapStatus = Apprenticeships.DetermineOverlap(apprenticeshipWeWantToAdd);
+
+            return actualOverlapStatus;
+        }
+
+        private void AssertSpecifiedDateIssueIsDetected(OverlapStatus actualOverlapStatus, OverlapStatus dateIssueBeingTested, bool expectedDateIssue)
+        {
+            var hasDateIssueBeingTested = (actualOverlapStatus & dateIssueBeingTested) != OverlapStatus.None;
+
+            if (expectedDateIssue)
+            {
+                Assert.IsTrue(hasDateIssueBeingTested, $"Actual detected overlap:{actualOverlapStatus}");
+            }
+            else
+            {
+                Assert.IsFalse(hasDateIssueBeingTested, $"Actual detected overlap:{actualOverlapStatus}");
+            }
+        }
+
+        private ApprenticeshipOverlapRulesTestFixtures AddApprenticeship(string uln, DateTime? startDate, DateTime? endDate, PaymentStatus paymentStatus)
+        {
+            var apprenticeship = CreateApprenticeship(uln, startDate, endDate, paymentStatus);
+            Apprenticeships.Add(apprenticeship);
+            return this;
+        }
+
+        private Apprenticeship CreateApprenticeship(string uln, DateTime? startDate, DateTime? endDate, PaymentStatus paymentStatus)
+        {
+            return new DraftApprenticeship
+            {
+                Id = Interlocked.Increment(ref _apprenticeshipId),
+                Uln = uln,
+                StartDate = startDate,
+                EndDate = endDate,
+                PaymentStatus = paymentStatus
+            };
+        }
+    }
+}

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2.UnitTests/Services/StringExtensions.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2.UnitTests/Services/StringExtensions.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Internal;
+
+namespace SFA.DAS.CommitmentsV2.UnitTests.Services
+{
+    internal static class StringExtensions
+    {
+        private static readonly string[] Months = new[]
+            {"JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"};
+
+        /// <summary>
+        ///     Convert a string in the format "Apr-19 to Jun-2019, Aug-20 or Jan-2021" into an enumeration of start-end period pairs.
+        /// </summary>
+        public static IEnumerable<(DateTime StartDate, DateTime EndDate)> StartEndPeriods(this string s)
+        {
+            return s.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                .Select(datePair => StartEndPeriod(datePair.Trim()));
+        }
+
+        /// <summary>
+        ///     Convert a string in the format "Apr-19 to Jun-2019" in to a pair of dates representing start and end.
+        /// </summary>
+        public static (DateTime StartDate, DateTime EndDate) StartEndPeriod(this string s)
+        {
+            // We don't actually care what comes in the middle - we'll use everything up to the first space as date 1 and 
+            // everything after the last space as date 2.
+
+            var firstSpace = s.IndexOf(' ');
+            var lastSpace = s.LastIndexOf(' ');
+
+            if (firstSpace == -1 || lastSpace == -1)
+            {
+                throw new InvalidOperationException($"The value {s} should be in the format \"mmm-yy to mmm-yy\" (or yy may be yyyy)");
+            }
+
+            var date1 = s.Substring(0, firstSpace);
+            var date2 = s.Substring(lastSpace+1);
+
+            return (date1.MonthYear(), date2.MonthYear());
+        }
+
+        /// <summary>
+        ///     Convert a string in the format Apr-19 or Apr-2019, Jun-20 or Jun-2020 etc
+        ///     in to a date of the 1st of the month.
+        /// </summary>
+        public static DateTime MonthYear(this string s)
+        {
+            var parts = s.Split('-').ToArray();
+            if (parts.Length != 2)
+            {
+                throw new InvalidOperationException($"The string {s} should have two parts separated by a dash: mmm-yy or mmm-yyyy");
+            }
+
+            if (parts[0].Length < 3)
+            {
+                throw new InvalidOperationException($"The string {s} should have a month part with at least three letters: mmm-yy or mmm-yyyy");
+            }
+
+            if (parts[1].Length != 2 && parts[1].Length != 4)
+            {
+                throw new InvalidOperationException($"The string {s} should have a year that is either 2 or 4 digits: mmm-yy or mmm-yyyy");
+            }
+
+            var month = parts[0].Substring(0, 3).ToUpperInvariant();
+
+            var monthIdx = Months.IndexOf(month);
+
+            if (monthIdx < 0)
+            {
+                throw new InvalidOperationException($"The month part in {s} ({month} is not a recognised month");
+            }
+
+            if (!int.TryParse(parts[1], out int year))
+            {
+                throw new InvalidOperationException($"The year part in {s} ({parts[1]} is not a valid year - should be yy or yyyy");
+            }
+
+            return new DateTime(year, monthIdx + 1, 1);
+        }
+    }
+}

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2/DependencyResolution/ValidationRegistry.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2/DependencyResolution/ValidationRegistry.cs
@@ -24,6 +24,8 @@ namespace SFA.DAS.CommitmentsV2.DependencyResolution
 
                 scan.AddAllTypesOf<IValidator>();
             });
+
+            For<IApprenticeshipOverlapService>().Use<ApprenticeshipOverlapService>().Singleton();
         }
     }
 }

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Domain/Interfaces/IApprenticeshipOverlapService.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Domain/Interfaces/IApprenticeshipOverlapService.cs
@@ -1,0 +1,12 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using SFA.DAS.CommitmentsV2.Domain.ValueObjects;
+using SFA.DAS.CommitmentsV2.Services;
+
+namespace SFA.DAS.CommitmentsV2.Domain.Interfaces
+{
+    public interface IApprenticeshipOverlapService
+    {
+        Task<OverlapStatus> CheckForOverlaps(DraftApprenticeshipDetails draftApprenticeshipDetails, CancellationToken cancellationToken);
+    }
+}

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Services/ApprenticeshipOverlapRules.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Services/ApprenticeshipOverlapRules.cs
@@ -1,0 +1,250 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using SFA.DAS.CommitmentsV2.Models;
+using SFA.DAS.CommitmentsV2.Api.Types.Types;
+using SFA.DAS.CommitmentsV2.Domain.ValueObjects;
+
+namespace SFA.DAS.CommitmentsV2.Services
+{
+    public static class ApprenticeshipExtensions
+    {
+        /// <summary>
+        ///     Determines whether the supplied apprenticeship overlaps any apprenticeships in the supplied collection.
+        /// </summary>
+        /// <param name="apprenticeships">
+        ///     The existing collection of apprenticeships for the same ULN. Only apprenticeships with the same
+        ///     ULN as that of <see cref="apprenticeship"/>> will be considered. If <see cref="apprenticeships"/>
+        ///     already contains an apprenticeship with the same id as <see cref="apprenticeship"/> then this
+        ///     will also be ignored when determining overlaps.
+        /// </param>
+        /// <param name="apprenticeship">The apprenticeship that is to tested to see whether it overlaps the existing apprenticeships.</param>
+        /// <returns>The overlap status</returns>
+        public static OverlapStatus DetermineOverlap(this IEnumerable<Apprenticeship> apprenticeships, Apprenticeship apprenticeship)
+        {
+            string MessagePart(DateTime? time, string s) => apprenticeship.StartDate.HasValue ? $" has {s}" : " is missing {s}";
+
+            if (!apprenticeship.StartDate.HasValue || !apprenticeship.EndDate.HasValue)
+            {
+                var msg =
+                    "Cannot determine overlap for apprentice without both a start date and end date. "+
+                    $"Apprentice {apprenticeship.Id} {MessagePart(apprenticeship.StartDate, "start date")} {MessagePart(apprenticeship.EndDate, "end date")}";
+
+                throw new InvalidOperationException(msg);
+            }
+
+            return apprenticeships.DetermineOverlap(
+                apprenticeship.Uln, 
+                apprenticeship.StartDate.Value, 
+                apprenticeship.EndDate.Value, 
+                apprenticeship.Id);
+        }
+
+        /// <summary>
+        ///     Determines whether the supplied draft apprenticeship overlaps any apprenticeships in the supplied collection.
+        /// </summary>
+        /// <param name="apprenticeships">
+        ///     The existing collection of apprenticeships for the same ULN. Only apprenticeships with the same
+        ///     ULN as that of <see cref="apprenticeship"/>> will be considered.
+        /// </param>
+        /// <param name="apprenticeship">The draft apprenticeship that is to tested to see whether it overlaps the existing apprenticeships.</param>
+        /// <returns>The overlap status</returns>
+        public static OverlapStatus DetermineOverlap(this IEnumerable<Apprenticeship> apprenticeships, DraftApprenticeshipDetails apprenticeship)
+        {
+            string MessagePart(DateTime? time, string s) => apprenticeship.StartDate.HasValue ? $" has {s}" : " is missing {s}";
+
+            if (!apprenticeship.StartDate.HasValue || !apprenticeship.EndDate.HasValue)
+            {
+                var msg =
+                    "Cannot determine overlap for apprentice without both a start date and end date. " +
+                    $"Uln {apprenticeship.Uln} {MessagePart(apprenticeship.StartDate, "start date")} {MessagePart(apprenticeship.EndDate, "end date")}";
+
+                throw new InvalidOperationException(msg);
+            }
+
+            return apprenticeships.DetermineOverlap(
+                apprenticeship.Uln,
+                apprenticeship.StartDate.Value,
+                apprenticeship.EndDate.Value,
+                null);
+        }
+
+        public static OverlapStatus DetermineOverlap(
+            this IEnumerable<Apprenticeship> apprenticeships, 
+            string uln, 
+            DateTime startDate, 
+            DateTime endDate, 
+            long? apprenticeshipId)
+        {
+            if (string.IsNullOrWhiteSpace(uln))
+            {
+                return OverlapStatus.None;
+            }
+
+            var applicableApprenticeships = apprenticeships
+                .Where(a => string.Equals(a.Uln, uln, StringComparison.OrdinalIgnoreCase) &&
+                            (!apprenticeshipId.HasValue || a.Id != apprenticeshipId))
+                .ToArray();
+
+            if (applicableApprenticeships.Length == 0)
+            {
+                return OverlapStatus.None;
+            }
+
+            OverlapStatus result = OverlapStatus.None;
+
+            foreach (var apprenticeship in applicableApprenticeships)
+            {
+                result = result | apprenticeship.DetermineOverlap(startDate, endDate);
+            }
+
+            return result;
+        }
+
+        public static DateTime GetEffectiveEndDate(this Apprenticeship apprenticeship)
+        {
+            //Get the appropriate dates for the apprenticeship
+            if (apprenticeship.PaymentStatus == PaymentStatus.Withdrawn)
+            {
+                if (!apprenticeship.StopDate.HasValue)
+                {
+                    throw new InvalidOperationException($"Cannot determine duration of the apprenticeship because the payment status is {nameof(PaymentStatus.Withdrawn)} but the stop date has not been set.");
+                }
+
+                return apprenticeship.StopDate.Value;
+            }
+
+            if (!apprenticeship.EndDate.HasValue)
+            {
+                throw new InvalidOperationException($"Cannot determine duration of the apprenticeship because the stop date has not been set.");
+            }
+
+            return apprenticeship.EndDate.Value;
+        }
+
+        public static OverlapStatus DetermineOverlap(this Apprenticeship apprenticeship, DateTime startDate, DateTime endDate)
+        {
+
+            DateTime apprenticeshipEffectiveEndDate = apprenticeship.GetEffectiveEndDate();
+
+            if (!apprenticeship.StartDate.HasValue)
+            {
+                throw new InvalidOperationException($"Cannot determine duration of the apprenticeship because the payment status is {nameof(PaymentStatus.Withdrawn)} but the start date has not been set.");
+            }
+
+            var apprenticeshipStartDate = apprenticeship.StartDate.Value.Date;
+
+            //Stopped before or on start date (effectively deleted) should be ignored
+            if (apprenticeship.PaymentStatus == PaymentStatus.Withdrawn && apprenticeshipStartDate == apprenticeshipEffectiveEndDate)
+            {
+                return OverlapStatus.None;
+            }
+
+            var overlapsStart = IsApprenticeshipDateBetween(startDate, apprenticeshipStartDate, apprenticeshipEffectiveEndDate);
+            var overlapsEnd = IsApprenticeshipDateBetween(endDate, apprenticeshipStartDate, apprenticeshipEffectiveEndDate);
+
+            //Contained
+            if (overlapsStart && overlapsEnd)
+            {
+                return OverlapStatus.DateWithin;
+            }
+
+            //Overlap start date
+            if (overlapsStart)
+            {
+                return OverlapStatus.OverlappingStartDate;
+            }
+
+            //Overlap end date
+            if (overlapsEnd)
+            {
+                return OverlapStatus.OverlappingEndDate;
+            }
+
+            //Straddle
+            if (IsApprenticeshipDateStraddle(startDate, endDate, apprenticeshipStartDate, apprenticeshipEffectiveEndDate))
+            {
+                return OverlapStatus.DateEmbrace;
+            }
+
+            return OverlapStatus.None;
+        }
+
+        private static bool IsApprenticeshipDateBetween(DateTime dateToCheck, DateTime dateFrom, DateTime dateTo)
+        {
+            return IsApprenticeshipDateAfter(dateToCheck, dateFrom) && IsDateBefore(dateToCheck, dateTo);
+        }
+
+        private static bool IsDateBefore(DateTime date1, DateTime date2)
+        {
+            if (date1.Year < date2.Year) return true;
+            if (date1.Year > date2.Year) return false;
+            if (date1.Month < date2.Month) return true;
+            if (date1.Month > date2.Month) return false;
+            return false;
+        }
+
+        private static bool IsApprenticeshipDateAfter(DateTime date1, DateTime date2)
+        {
+            return IsDateBefore(date2, date1);
+        }
+
+        private static bool IsApprenticeshipDateStraddle(DateTime date1Start, DateTime date1End, DateTime date2Start, DateTime date2End)
+        {
+            //straightforward case - clear straddle
+            if (IsDateBefore(date1Start, date2Start) && IsApprenticeshipDateAfter(date1End, date2End))
+            {
+                return true;
+            }
+
+            //Case where active apprenticeship is single-month, cannot overlap
+            if (IsSameMonthAndYear(date2Start, date2End))
+            {
+                return false;
+            }
+
+            //Case where timespans are identical
+            if (IsSameMonthAndYear(date1Start, date2Start) && IsSameMonthAndYear(date1End, date2End))
+            {
+                //Then single month apprenticeships do not overlap
+                if (IsSameMonthAndYear(date1Start, date1End))
+                {
+                    return false;
+                }
+
+                return true;
+            }
+
+            //If the apprenticeships share a start date
+            if (IsSameMonthAndYear(date1Start, date2Start))
+            {
+                //The if is a single month then do not overlap
+                if (IsSameMonthAndYear(date1Start, date1End))
+                {
+                    return false;
+                }
+
+                return true;
+            }
+
+            //If they share an end date
+            if (IsSameMonthAndYear(date1End, date2End))
+            {
+                //Then if is a single month then do not overlap
+                if (IsSameMonthAndYear(date1Start, date1End))
+                {
+                    return false;
+                }
+
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool IsSameMonthAndYear(DateTime date1, DateTime date2)
+        {
+            return date1.Month == date2.Month && date1.Year == date2.Year;
+        }
+    }
+}

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Services/ApprenticeshipOverlapService.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Services/ApprenticeshipOverlapService.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentValidation.Validators;
+using Microsoft.EntityFrameworkCore;
+using SFA.DAS.CommitmentsV2.Data;
+using SFA.DAS.CommitmentsV2.Domain.Interfaces;
+using SFA.DAS.CommitmentsV2.Domain.ValueObjects;
+using SFA.DAS.CommitmentsV2.Models;
+
+namespace SFA.DAS.CommitmentsV2.Services
+{
+    public class ApprenticeshipOverlapService : IApprenticeshipOverlapService
+    {
+        private readonly IDbContextFactory _dbContextFactory;
+
+        public ApprenticeshipOverlapService(IDbContextFactory dbContextFactory)
+        {
+            _dbContextFactory = dbContextFactory;
+        }
+
+        public async Task<OverlapStatus> CheckForOverlaps(
+            DraftApprenticeshipDetails draftApprenticeshipDetails,
+            CancellationToken cancellationToken)
+        {
+            using (var db = _dbContextFactory.CreateAccountsDbContext())
+            {
+                var apprenticeships = await db.DraftApprenticeships
+                    .Where(da => da.Uln == draftApprenticeshipDetails.Uln)
+                    .AsNoTracking()
+                    .OfType<Apprenticeship>()
+                    .ToListAsync(cancellationToken);
+
+                apprenticeships.AddRange(await db.ConfirmedApprenticeships
+                    .Where(ca => ca.Uln == draftApprenticeshipDetails.Uln)
+                    .AsNoTracking()
+                    .ToListAsync(cancellationToken));
+
+                return apprenticeships.DetermineOverlap(draftApprenticeshipDetails);
+            }
+        }
+
+    }
+}

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Services/OverlapStatus.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Services/OverlapStatus.cs
@@ -1,0 +1,79 @@
+﻿using System;
+
+namespace SFA.DAS.CommitmentsV2.Services
+{
+    /// <summary>
+    ///     A flag enum that describes how the proposed start and end dates overlap another
+    ///     apprenticeship.
+    /// </summary>
+    /// <remarks>
+    ///     Aggregating this result to a set:
+    ///     The <see cref="DateEmbrace"/> and <see cref="DateWithin"/> values describes the 
+    ///     proposed apprenticeship with regards to a single apprenticeship, not a set.
+    ///     So for example, if an apprentice had two existing apprenticeships that ran from
+    ///     Jan-19 to Mar-19 and Jun-19 to Aug-19 then proposing an apprenticeship that
+    ///     ran from Mar-19 Jul-19 would *not* set the DateWithin. This is because even though
+    ///     the existing apprenticeships run from Jan-Aug and the proposed apprenticeship runs
+    ///     from Mar-Jul the flag only indicates the situation with regards to a *single*
+    ///     apprenticeship, not the set.
+    /// </remarks>
+    [Flags]
+    public enum OverlapStatus
+    {
+        /// <summary>
+        ///     No overlaps exist
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        ///     The proposed start date overlaps with an existing apprenticeship
+        ///     For example:
+        ///         Existing apprenticeship runs Mar-19 to Oct-19
+        ///         Proposed apprenticeship runs Sep-19 to Dec-19
+        ///     The start of the proposed apprenticeship overlaps the existing apprenticeship.
+        /// </summary>
+        OverlappingStartDate = 1,
+
+        /// <summary>
+        ///     The proposed end date overlaps with an existing apprenticeship
+        ///     For example:
+        ///         Existing apprenticeship runs Mar-19 to Oct-19
+        ///         Proposed apprenticeship runs Jan-19 to Apr-19
+        ///     The end of the proposed apprenticeship overlaps the existing apprenticeship.
+        /// </summary>
+        OverlappingEndDate = 2,
+
+        /// <summary>
+        ///     The proposed start date and end date completely embrace (contain) an existing apprenticeship
+        ///     For example:
+        ///         Existing apprenticeship runs Mar-19 to Oct-19
+        ///         Proposed apprenticeship runs Jan-19 to Nov-19
+        ///     The existing apprenticeship is completely contained within the proposed apprenticeship.
+        /// </summary>
+        DateEmbrace = 4,
+
+        /// <summary>
+        ///     The proposed start date and end date are completely within an existing apprenticeship
+        ///     For example:
+        ///         Existing apprenticeship runs Mar-19 to Oct-19
+        ///         Proposed apprenticeship runs Apr-19 to Jun-19
+        ///     The proposed apprenticeship is completely contained within the existing apprenticeship.
+        /// </summary>
+        DateWithin = 8,
+
+        /// <summary>
+        ///     Short cut to <see cref="OverlappingStartDate"/> and <see cref="OverlappingEndDate"/>.
+        /// </summary>
+        OverlappingDates = OverlappingStartDate | OverlappingEndDate,
+
+        /// <summary>
+        ///     Indicates that the problem could be fixed by adjusting the proposed start date.
+        /// </summary>
+        ProblemWithStartDate = OverlappingStartDate | DateEmbrace | DateWithin,
+
+        /// <summary>
+        ///     Indicates that the problem could be fixed by adjusting the proposed end date.
+        /// </summary>
+        ProblemWithEndDate = OverlappingEndDate | DateEmbrace | DateWithin
+    }
+}

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Validators/AddDraftApprenticeshipModelValidator.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Validators/AddDraftApprenticeshipModelValidator.cs
@@ -34,7 +34,7 @@ namespace SFA.DAS.CommitmentsV2.Validators
                 .CustomAsync(async (ctx, customContext, cancellationToken) => await ValidateReservationId(reservationsApiClient, ctx, customContext, cancellationToken));
         }
 
-        private static async Task<bool> ValidateReservationId(
+        private async Task<bool> ValidateReservationId(
             IReservationsApiClient reservationsApiClient,
             AddDraftApprenticeshipModel ctx, 
             CustomContext customContext, 

--- a/src/SFA.DAS.Commitments.Application.UnitTests/Rules/ApprenticeshipOverlapRules/ApprenticeshipOverlapRulesTests.cs
+++ b/src/SFA.DAS.Commitments.Application.UnitTests/Rules/ApprenticeshipOverlapRules/ApprenticeshipOverlapRulesTests.cs
@@ -1,0 +1,143 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using NUnit.Framework;
+using SFA.DAS.Commitments.Domain.Entities;
+using SFA.DAS.Commitments.Domain.Entities.Validation;
+
+namespace SFA.DAS.Commitments.Application.UnitTests.Rules.ApprenticeshipOverlapRules
+{
+    internal static class StringExtensions
+    {
+        private static readonly List<string> Months = new List<string>
+            {"JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"};
+
+        /// <summary>
+        ///     Convert a string in the format Apr-19 or Apr-2019, Jun-20 or Jun-2020 etc
+        ///     in to a date of the 1st of the month.
+        /// </summary>
+        public static DateTime MonthYear(this string s)
+        {
+            var parts = s.Split('-').ToArray();
+            if (parts.Length != 2)
+            {
+                throw new InvalidOperationException($"The string {s} should have two parts separated by a dash: mmm-yy or mmm-yyyy");
+            }
+
+            if (parts[0].Length < 3)
+            {
+                throw new InvalidOperationException($"The string {s} should have a month part with at least three letters: mmm-yy or mmm-yyyy");
+            }
+
+            if (parts[1].Length != 2 && parts[1].Length != 4)
+            {
+                throw new InvalidOperationException($"The string {s} should have a year that is either 2 or 4 digits: mmm-yy or mmm-yyyy");
+            }
+
+            var month = parts[0].Substring(0,3).ToUpperInvariant();
+
+            var monthIdx = Months.IndexOf(month);
+
+            if (monthIdx < 0)
+            {
+                throw new InvalidOperationException($"The month part in {s} ({month} is not a recognised month");
+            }
+
+            if (!int.TryParse(parts[1], out int year))
+            {
+                throw new InvalidOperationException($"The year part in {s} ({parts[1]} is not a valid year - should be yy or yyyy");
+            }
+
+            return new DateTime(year, monthIdx+1, 1);
+        }
+    }
+
+    [TestFixture]
+    public class ApprenticeshipOverlapRulesTests
+    {
+        [TestCase("May-19", "Jul-19", "Jan-19", "Feb-19", ValidationFailReason.None)]
+        [TestCase("May-19", "Jul-19", "Jan-19", "May-19", ValidationFailReason.None)]
+        [TestCase("May-19", "Jul-19", "Jan-19", "Jun-19", ValidationFailReason.OverlappingEndDate)]
+        [TestCase("May-19", "Jul-19", "May-19", "Jul-19", ValidationFailReason.DateEmbrace)]
+        [TestCase("May-19", "Jul-19", "Jun-19", "Aug-19", ValidationFailReason.OverlappingStartDate)]
+        [TestCase("May-19", "Jul-19", "Jul-19", "Aug-19", ValidationFailReason.None)]
+        [TestCase("May-19", "Aug-19", "Jun-19", "Jul-19", ValidationFailReason.DateWithin)]
+        public void SingleApprenticeship_WithExplicitStartAndEndDates_ShouldDetermineOverlapCorrectly(string apprenticeshipStart, string apprenticeshipEnd, string testStart, string testEnd, ValidationFailReason expectedOverlapStatus)
+        {
+            var fixtures = new ApprenticeshipOverlapRulesTestFixtures()
+                                .WithConfirmedApprenticeship("123", apprenticeshipStart.MonthYear(), apprenticeshipEnd.MonthYear());
+
+            fixtures.AssertApprenticeOverlapStatus(testStart.MonthYear(), testEnd.MonthYear(), expectedOverlapStatus);
+        }
+    }
+
+    public class ApprenticeshipOverlapRulesTestFixtures
+    {
+        private int _apprenticeshipId = 0;
+
+        public ApprenticeshipOverlapRulesTestFixtures()
+        {
+            Apprenticeships = new List<ApprenticeshipResult>();    
+        }
+
+        public List<ApprenticeshipResult> Apprenticeships { get; }
+
+        public ApprenticeshipOverlapRulesTestFixtures WithDraftApprenticeship(string uln, DateTime startDate, DateTime endDate)
+        {
+            return AddApprenticeship(uln, startDate, endDate, PaymentStatus.PendingApproval);
+        }
+
+        public ApprenticeshipOverlapRulesTestFixtures WithConfirmedApprenticeship(string uln, DateTime startDate, DateTime endDate)
+        {
+            return AddApprenticeship(uln, startDate, endDate, PaymentStatus.Active);
+        }
+
+        public ApprenticeshipOverlapRulesTestFixtures AndCancelApprenticeship(string uln, DateTime stopDate,
+            PaymentStatus paymentStatus)
+        {
+            var apprenticeship = Apprenticeships.Last();
+
+            apprenticeship.StopDate = stopDate;
+            apprenticeship.PaymentStatus = PaymentStatus.Withdrawn;
+
+            return this;
+        }
+
+        public void AssertApprenticeOverlapStatus(DateTime startDate, DateTime endDate, ValidationFailReason expectedOverlapStatus)
+        {
+            var rules = new Application.Rules.ApprenticeshipOverlapRules();
+            var apprenticeship = Apprenticeships.First();
+
+            var request = new ApprenticeshipOverlapValidationRequest
+            {
+                Uln = apprenticeship.Uln,
+                StartDate = startDate,
+                EndDate = endDate
+            };
+
+            var actualOverlapStatus = rules.DetermineOverlap(request, apprenticeship);
+
+            Assert.AreEqual(expectedOverlapStatus, actualOverlapStatus);
+        }
+
+        private ApprenticeshipOverlapRulesTestFixtures AddApprenticeship(string uln, DateTime startDate, DateTime endDate, PaymentStatus paymentStatus)
+        {
+            var apprenticeship = CreateApprenticeship(uln, startDate, endDate, paymentStatus);
+            Apprenticeships.Add(apprenticeship);
+            return this;
+        }
+
+        private ApprenticeshipResult CreateApprenticeship(string uln, DateTime startDate, DateTime endDate, PaymentStatus paymentStatus)
+        {
+            return new ApprenticeshipResult
+            {
+                Id = Interlocked.Increment(ref _apprenticeshipId),
+                Uln = uln,
+                StartDate = startDate,
+                EndDate =  endDate,
+                PaymentStatus = paymentStatus
+            };
+        }
+    }
+}

--- a/src/SFA.DAS.Commitments.Application.UnitTests/SFA.DAS.Commitments.Application.UnitTests.csproj
+++ b/src/SFA.DAS.Commitments.Application.UnitTests/SFA.DAS.Commitments.Application.UnitTests.csproj
@@ -238,6 +238,7 @@
     <Compile Include="Queries\GetProviderCommitments\WhenGettingProviderCommitments.cs" />
     <Compile Include="Queries\GetProviderCommitments\WhenValidatingProviderId.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Rules\ApprenticeshipOverlapRules\ApprenticeshipOverlapRulesTests.cs" />
     <Compile Include="Rules\ApprenticeshipUpdateRules\WhenDetermineNewCommmitmentStatus.cs" />
     <Compile Include="Rules\ApprenticeshipUpdateRules\WhenDetermineNewEditStatus.cs" />
     <Compile Include="Rules\ApprenticeshipUpdateRules\WhenDetermineNewPaymentStatus.cs" />
@@ -287,7 +288,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Queries\GetFilteredApprenticeship\" />
-    <Folder Include="Rules\ApprenticeshipOverlapRules\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">


### PR DESCRIPTION
This adds an IApprenticeshipOverlapService and some extension methods to IEnumerable<Apprenticeship> to allow overlap testing on in-memory apprenticeships.
The unit tests for validation have been amended to put back in testing of property names and error messages that were previously inadvertently lost.