### PR TITLE
CV-423 Add logging when a commitmentApiModelException is created

### DIFF
--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Api.Client.UnitTests/Fakes/FakeLogger.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Api.Client.UnitTests/Fakes/FakeLogger.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.Extensions.Logging;
+using SFA.DAS.CommitmentsV2.Api.Client.Http;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace SFA.DAS.CommitmentsV2.Api.Client.UnitTests.Fakes
+{
+    public class LogMessage
+    {
+        public LogMessage(LogLevel logLevel, string message)
+        {
+            LogLevel = logLevel;
+            Message = message;
+        }
+        public LogLevel LogLevel { get; }
+        public string Message { get; }
+    }
+
+    public class FakeLogger : ILogger<CommitmentsRestHttpClient>
+    {
+        private readonly List<LogLevel> _enabledLogLevels = new List<LogLevel>();
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (IsEnabled(logLevel))
+            {
+                Messages.Add(new LogMessage(logLevel, formatter(state, exception)));
+            }
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return _enabledLogLevels.Contains(logLevel);
+        }
+
+        public IDisposable BeginScope<TState>(TState state)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void EnableLevel(LogLevel logLevel)
+        {
+            if (!_enabledLogLevels.Contains(logLevel))
+            {
+                _enabledLogLevels.Add(logLevel);
+            }
+        }
+
+        public List<LogMessage> Messages { get; } = new List<LogMessage>();
+
+        public bool ContainsMessage(Func<LogMessage, bool> matches)
+        {
+            return Messages.Any(matches);
+        }
+    }
+}

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Api.Client/CommitmentsApiClientFactory.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Api.Client/CommitmentsApiClientFactory.cs
@@ -20,7 +20,7 @@ namespace SFA.DAS.CommitmentsV2.Api.Client
         {
             var httpClientFactory = new AzureActiveDirectoryHttpClientFactory(_configuration, _loggerFactory);
             var httpClient = httpClientFactory.CreateHttpClient();
-            var restHttpClient = new CommitmentsRestHttpClient(httpClient);
+            var restHttpClient = new CommitmentsRestHttpClient(httpClient, _loggerFactory);
             var apiClient = new CommitmentsApiClient(restHttpClient);
 
             return apiClient;

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Api.Client/Http/CommitmentsRestHttpClient.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Api.Client/Http/CommitmentsRestHttpClient.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using SFA.DAS.CommitmentsV2.Api.Types.Http;
 using SFA.DAS.CommitmentsV2.Api.Types.Validation;
@@ -10,15 +13,34 @@ namespace SFA.DAS.CommitmentsV2.Api.Client.Http
 {
     public class CommitmentsRestHttpClient : RestHttpClient
     {
-        public CommitmentsRestHttpClient(HttpClient httpClient) : base(httpClient)
+        private readonly ILogger<CommitmentsRestHttpClient> _logger;
+
+        public CommitmentsRestHttpClient(HttpClient httpClient, ILoggerFactory loggerFactory) : base(httpClient)
         {
+            _logger = loggerFactory.CreateLogger<CommitmentsRestHttpClient>();
         }
 
         protected override Exception CreateClientException(HttpResponseMessage httpResponseMessage, string content)
         {
             return httpResponseMessage.StatusCode == HttpStatusCode.BadRequest && httpResponseMessage.GetSubStatusCode() == HttpSubStatusCode.DomainException
-                ? new CommitmentsApiModelException(JsonConvert.DeserializeObject<ErrorResponse>(content).Errors)
+                ? CreateApiModelException(httpResponseMessage, content)
                 : base.CreateClientException(httpResponseMessage, content);
+        }
+
+        private Exception CreateApiModelException(HttpResponseMessage httpResponseMessage, string content)
+        {
+            if (string.IsNullOrWhiteSpace(content))
+            {
+                _logger.LogWarning($"{httpResponseMessage.RequestMessage.RequestUri} has returned an empty string when an array of error responses was expected.");
+                return new CommitmentsApiModelException(new List<ErrorDetail>());
+            }
+
+            var errors = new CommitmentsApiModelException(JsonConvert.DeserializeObject<ErrorResponse>(content).Errors);
+
+            var errorDetails = string.Join(";", errors.Errors.Select(e => $"{e.Field} ({e.Message})"));
+            _logger.Log(errors.Errors.Count == 0 ? LogLevel.Warning : LogLevel.Debug, $"{httpResponseMessage.RequestMessage.RequestUri} has returned {errors.Errors.Count} errors: {errorDetails}");
+
+            return errors;
         }
     }
 }


### PR DESCRIPTION
The API client nuget from this is intended to be consumed by Employer Commitments V2 so that we can see what it is receiving from the API in PreProd.