### PR TITLE
Changed status to the correct type

### DIFF
--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Api.Client/CommitmentsApiClient.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Api.Client/CommitmentsApiClient.cs
@@ -1,5 +1,4 @@
-﻿using System.Globalization;
-using System.Net;
+﻿using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using SFA.DAS.CommitmentsV2.Api.Types.Responses;

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Api.Types/Responses/GetApprenticeshipsFilterValuesResponse.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Api.Types/Responses/GetApprenticeshipsFilterValuesResponse.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using SFA.DAS.CommitmentsV2.Types;
 
 namespace SFA.DAS.CommitmentsV2.Api.Types.Responses
 {
@@ -7,7 +8,7 @@ namespace SFA.DAS.CommitmentsV2.Api.Types.Responses
     {
         public IEnumerable<string> EmployerNames { get; set; }
         public IEnumerable<string> CourseNames { get; set; }
-        public IEnumerable<string> Statuses { get; set; }
+        public IEnumerable<PaymentStatus> Statuses { get; set; }
         public IEnumerable<DateTime> StartDates { get; set; }
         public IEnumerable<DateTime> EndDates { get; set; }
     }

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Api.UnitTests/Controllers/ApprenticeshipControllerTests/ApprenticeshipFilterControllerTests.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Api.UnitTests/Controllers/ApprenticeshipControllerTests/ApprenticeshipFilterControllerTests.cs
@@ -10,6 +10,7 @@ using NUnit.Framework;
 using SFA.DAS.CommitmentsV2.Api.Controllers;
 using SFA.DAS.CommitmentsV2.Application.Queries.GetApprenticeshipsFilterValues;
 using SFA.DAS.CommitmentsV2.Shared.Interfaces;
+using SFA.DAS.CommitmentsV2.Types;
 
 namespace SFA.DAS.CommitmentsV2.Api.UnitTests.Controllers.ApprenticeshipControllerTests
 {
@@ -54,7 +55,7 @@ namespace SFA.DAS.CommitmentsV2.Api.UnitTests.Controllers.ApprenticeshipControll
             {
                 EmployerNames = new[] {"Test 1", "Test 2"},
                 CourseNames = new[] {"Test 3", "Test 4"},
-                Statuses = new[] { "Test 5", "Test 6" },
+                Statuses = new[] { PaymentStatus.Active, PaymentStatus.Completed },
                 StartDates = new[] { DateTime.Now.AddDays(-1), DateTime.Now.AddDays(-2) },
                 EndDates = new[] { DateTime.Now.AddDays(-3), DateTime.Now.AddDays(-4) }
             };

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2.UnitTests/Application/Queries/GetApprovedApprenticesFilterValues/GetApprovedApprenticesFilterValuesQueryHandlerTests.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2.UnitTests/Application/Queries/GetApprovedApprenticesFilterValues/GetApprovedApprenticesFilterValuesQueryHandlerTests.cs
@@ -73,12 +73,12 @@ namespace SFA.DAS.CommitmentsV2.UnitTests.Application.Queries.GetApprovedApprent
             approvedApprenticeships[0].Cohort.ProviderId = query.ProviderId;
             approvedApprenticeships[1].Cohort.ProviderId = query.ProviderId;
             approvedApprenticeships[2].Cohort.ProviderId = query.ProviderId;
-            approvedApprenticeships[2].Cohort.CommitmentStatus = approvedApprenticeships[1].Cohort.CommitmentStatus;
+            approvedApprenticeships[2].PaymentStatus = approvedApprenticeships[1].PaymentStatus;
 
             var expectedStatuses = new[]
                 {
-                    Enum.GetName(typeof(CommitmentStatus), approvedApprenticeships[0].Cohort.CommitmentStatus),
-                    Enum.GetName(typeof(CommitmentStatus), approvedApprenticeships[1].Cohort.CommitmentStatus)
+                    approvedApprenticeships[0].PaymentStatus,
+                    approvedApprenticeships[1].PaymentStatus
                 };
 
             mockContext

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Application/Queries/GetApprenticeshipsFilterValues/GetApprenticeshipsFilterValuesQueryResult.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Application/Queries/GetApprenticeshipsFilterValues/GetApprenticeshipsFilterValuesQueryResult.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using SFA.DAS.CommitmentsV2.Types;
 
 namespace SFA.DAS.CommitmentsV2.Application.Queries.GetApprenticeshipsFilterValues
 {
@@ -7,7 +8,7 @@ namespace SFA.DAS.CommitmentsV2.Application.Queries.GetApprenticeshipsFilterValu
     {
         public IEnumerable<string> EmployerNames { get; set; }
         public IEnumerable<string> CourseNames { get; set; }
-        public IEnumerable<string> Statuses { get; set; }
+        public IEnumerable<PaymentStatus> Statuses { get; set; }
         public IEnumerable<DateTime> StartDates { get; set; }
         public IEnumerable<DateTime> EndDates { get; set; }
     }


### PR DESCRIPTION
We should be using the apprenticeship payment status and will be sending over the enum rather than the name of the emun so that it can be mapped at the client end to the required values