### PR TITLE
MF-506 - Add AccountLegalEntityId to Search response

### DIFF
--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Api.Types/Responses/GetApprenticeshipsResponse.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Api.Types/Responses/GetApprenticeshipsResponse.cs
@@ -32,6 +32,7 @@ namespace SFA.DAS.CommitmentsV2.Api.Types.Responses
             public string EmployerRef { get; set; }
             public string ProviderRef { get; set; }
             public string CohortReference { get; set; }
+            public long AccountLegalEntityId { get; set; }
         }
     }
 }

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2.UnitTests/Mapping/Apprenticeships/ApprenticeshipToApprenticeshipDetailsMapperTests.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2.UnitTests/Mapping/Apprenticeships/ApprenticeshipToApprenticeshipDetailsMapperTests.cs
@@ -43,6 +43,7 @@ namespace SFA.DAS.CommitmentsV2.UnitTests.Mapping.Apprenticeships
             result.EmployerRef.Should().Be(source.EmployerRef);
             result.TotalAgreedPrice.Should().Be(cost);
             result.CohortReference.Should().Be(source.Cohort.Reference);
+            result.AccountLegalEntityId.Should().Be(source.Cohort.AccountLegalEntityId);
         }
 
     }

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Application/Queries/GetApprenticeships/GetApprenticeshipsQueryResult.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Application/Queries/GetApprenticeships/GetApprenticeshipsQueryResult.cs
@@ -32,6 +32,7 @@ namespace SFA.DAS.CommitmentsV2.Application.Queries.GetApprenticeships
             public string EmployerRef { get; set; }
             public decimal? TotalAgreedPrice { get; set; }
             public string CohortReference { get; set; }
+            public long AccountLegalEntityId { get; set; }
         }
     }
 }

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Mapping/Apprenticeships/ApprenticeshipToApprenticeshipDetailsMapper.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Mapping/Apprenticeships/ApprenticeshipToApprenticeshipDetailsMapper.cs
@@ -42,7 +42,8 @@ namespace SFA.DAS.CommitmentsV2.Mapping.Apprenticeships
                 ApprenticeshipStatus = source.MapApprenticeshipStatus(_currentDateTime),
                 TotalAgreedPrice = source.PriceHistory.GetPrice(_currentDateTime.UtcNow),
                 Uln = source.Uln,
-                Alerts = source.MapAlerts()
+                Alerts = source.MapAlerts(),
+                AccountLegalEntityId = source.Cohort.AccountLegalEntityId
             });
         }
 

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Mapping/ResponseMappers/GetApprenticeshipsResponseMapper.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Mapping/ResponseMappers/GetApprenticeshipsResponseMapper.cs
@@ -42,7 +42,8 @@ namespace SFA.DAS.CommitmentsV2.Mapping.ResponseMappers
                 PaymentStatus = source.PaymentStatus,
                 ApprenticeshipStatus = source.ApprenticeshipStatus,
                 Alerts = source.Alerts,
-                TotalAgreedPrice = source.TotalAgreedPrice
+                TotalAgreedPrice = source.TotalAgreedPrice,
+                AccountLegalEntityId = source.AccountLegalEntityId
             };
         }
     }


### PR DESCRIPTION
Additional fields for provider download. Set MF-505 as base so the changes can be seen easier.