### PR TITLE
Add default request header to Payments API httpClient to look for ver…

### DIFF
--- a/src/SFA.DAS.CommitmentPayments.WebJob/DependencyResolution/PaymentsRegistry.cs
+++ b/src/SFA.DAS.CommitmentPayments.WebJob/DependencyResolution/PaymentsRegistry.cs
@@ -29,6 +29,7 @@ namespace SFA.DAS.CommitmentPayments.WebJob.DependencyResolution
                     .WithDefaultHeaders()
                     .Build();
 
+            httpClient.DefaultRequestHeaders.Add("api-version", "2");
 
             return httpClient;
         }


### PR DESCRIPTION
…sion 2. Since removing the SecureHttpClient from PaymentEventsApiClient this header was lost. This only matters for data locks as that is the only controller action split by api version at present