### PR TITLE
FAT2-430 - Remove old FATv1 configuration code

### DIFF
--- a/src/SFA.DAS.Commitments.Api/DependencyResolution/DefaultRegistry.cs
+++ b/src/SFA.DAS.Commitments.Api/DependencyResolution/DefaultRegistry.cs
@@ -65,8 +65,6 @@ namespace SFA.DAS.Commitments.Api.DependencyResolution
 
             For<IEventsApi>().Use<DummyEventsApiClient>();
 
-            For<IApprenticeshipInfoServiceConfiguration>().Use(config.ApprenticeshipInfoService);
-
             For<IAcademicYearDateProvider>().Use<AcademicYearDateProvider>();
             For<IUlnValidator>().Use<UlnValidator>();
             For<IAcademicYearValidator>().Use<AcademicYearValidator>();

--- a/src/SFA.DAS.Commitments.Domain/Entities/TrainingProgramme/IApprenticeshipInfoServiceConfiguration.cs
+++ b/src/SFA.DAS.Commitments.Domain/Entities/TrainingProgramme/IApprenticeshipInfoServiceConfiguration.cs
@@ -1,7 +1,0 @@
-namespace SFA.DAS.Commitments.Domain.Entities.TrainingProgramme
-{
-    public interface IApprenticeshipInfoServiceConfiguration
-    {
-        string BaseUrl { get; set; }
-    }
-}

--- a/src/SFA.DAS.Commitments.Domain/SFA.DAS.Commitments.Domain.csproj
+++ b/src/SFA.DAS.Commitments.Domain/SFA.DAS.Commitments.Domain.csproj
@@ -157,7 +157,6 @@
     <Compile Include="Entities\ProviderUser.cs" />
     <Compile Include="Entities\TrainingProgramme\Framework.cs" />
     <Compile Include="Entities\TrainingProgramme\FrameworksView.cs" />
-    <Compile Include="Entities\TrainingProgramme\IApprenticeshipInfoServiceConfiguration.cs" />
     <Compile Include="Entities\TrainingProgramme\ITrainingProgramme.cs" />
     <Compile Include="Entities\TrainingProgramme\Standard.cs" />
     <Compile Include="Entities\TrainingProgramme\StandardsView.cs" />

--- a/src/SFA.DAS.Commitments.Infrastructure/Configuration/ApprenticeshipInfoServiceConfiguration.cs
+++ b/src/SFA.DAS.Commitments.Infrastructure/Configuration/ApprenticeshipInfoServiceConfiguration.cs
@@ -1,9 +1,0 @@
-﻿using SFA.DAS.Commitments.Domain.Entities.TrainingProgramme;
-
-namespace SFA.DAS.Commitments.Infrastructure.Configuration
-{
-    public class ApprenticeshipInfoServiceConfiguration : IApprenticeshipInfoServiceConfiguration
-    {
-        public string BaseUrl { get; set; }
-    }
-}

--- a/src/SFA.DAS.Commitments.Infrastructure/Configuration/CommitmentsApiConfiguration.cs
+++ b/src/SFA.DAS.Commitments.Infrastructure/Configuration/CommitmentsApiConfiguration.cs
@@ -12,7 +12,6 @@ namespace SFA.DAS.Commitments.Infrastructure.Configuration
         public string Hashstring { get; set; }
         public string AllowedHashstringCharacters { get; set; }
         public EventsApiClientConfiguration EventsApi { get; set; }
-        public ApprenticeshipInfoServiceConfiguration ApprenticeshipInfoService { get; set; }
         public string MessageServiceBusConnectionString { get; set; }
         public NServiceBusConfiguration NServiceBusConfiguration { get; set; }
         public EmployerAccountsApiClientConfiguration AccountApi { get; set; }

--- a/src/SFA.DAS.Commitments.Infrastructure/SFA.DAS.Commitments.Infrastructure.csproj
+++ b/src/SFA.DAS.Commitments.Infrastructure/SFA.DAS.Commitments.Infrastructure.csproj
@@ -213,7 +213,6 @@
     <Compile Include="AzureStorage\AzureBlobStorage.cs" />
     <Compile Include="AzureStorage\IAzureBlobStorage.cs" />
     <Compile Include="Configuration\EmployerAccountsApiClientConfiguration.cs" />
-    <Compile Include="Configuration\ApprenticeshipInfoServiceConfiguration.cs" />
     <Compile Include="Configuration\CommitmentsApiConfiguration.cs" />
     <Compile Include="Configuration\Configuration.cs" />
     <Compile Include="Configuration\CurrentDatePolicy.cs" />


### PR DESCRIPTION
Removed old configuration code and updated container registration so that it no longer loaded the FATv1 url