### PR TITLE
CS-1364 Fix query to count apprenticeships with missing email addresses 

### DIFF
--- a/src/SFA.DAS.Commitments.Database/Views/ApprenticeshipsWithNoEmail.sql
+++ b/src/SFA.DAS.Commitments.Database/Views/ApprenticeshipsWithNoEmail.sql
@@ -5,5 +5,5 @@ SELECT
 	A.Id AS ApprenticeshipId
 FROM Apprenticeship A
 INNER JOIN Commitment C ON A.CommitmentId = C.Id
-WHERE A.IsApproved = 1 AND C.EmployerAndProviderApprovedOn >= '2000-09-10' AND A.Email IS NULL
+WHERE A.IsApproved = 1 AND C.EmployerAndProviderApprovedOn >= '2021-09-10' AND A.Email IS NULL AND A.ContinuationOfId IS NULL
 GO


### PR DESCRIPTION
It now correctly excludes continuations of apprenticeships