### PR TITLE
update outer api client to set apim headers in the request rather tha…

### DIFF
--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Infrastructure/ApprovalsOuterApiClient.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Infrastructure/ApprovalsOuterApiClient.cs
@@ -26,15 +26,18 @@ namespace SFA.DAS.CommitmentsV2.Infrastructure
             _httpClient = httpClient;
             _httpClient.BaseAddress = new Uri(_config.BaseUrl);
             _asyncRetryPolicy = GetRetryPolicy();
-
-            AddHeaders();
         }
 
         public async Task<TResponse> Get<TResponse>(IGetApiRequest request) 
         {
 
             _logger.LogInformation("Calling Outer API base {0}, url {1}", _config.BaseUrl, request.GetUrl);
-            var response = await _httpClient.GetAsync(request.GetUrl).ConfigureAwait(false);
+
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, request.GetUrl);
+
+            AddHeaders(httpRequestMessage);
+
+            var response = await _httpClient.SendAsync(httpRequestMessage).ConfigureAwait(false);
 
             if (response.StatusCode.Equals(HttpStatusCode.NotFound))
             {
@@ -60,10 +63,10 @@ namespace SFA.DAS.CommitmentsV2.Infrastructure
             return await _asyncRetryPolicy.ExecuteAsync(async() => await Get<TResponse>(request));
         }
 
-        private void AddHeaders()
+        private void AddHeaders(HttpRequestMessage httpRequestMessage)
         {
-            _httpClient.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", _config.Key);
-            _httpClient.DefaultRequestHeaders.Add("X-Version", "1");
+            httpRequestMessage.Headers.Add("Ocp-Apim-Subscription-Key", _config.Key);
+            httpRequestMessage.Headers.Add("X-Version", "1");
         }
 
         private AsyncRetryPolicy GetRetryPolicy()


### PR DESCRIPTION
…n default headers of the client. This can become a problem if the lifetime scope of the httpClient is changed.