### PR TITLE
change to a run continuous model using an in-memory lastID in case an…

### DIFF
--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Jobs.UnitTests/ScheduledJobs/DataLockUpdaterJobsTests.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Jobs.UnitTests/ScheduledJobs/DataLockUpdaterJobsTests.cs
@@ -1,10 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
 using AutoFixture.NUnit3;
 using Moq;
 using NUnit.Framework;
 using SFA.DAS.CommitmentsV2.Domain.Interfaces;
 using SFA.DAS.CommitmentsV2.Jobs.ScheduledJobs;
 using SFA.DAS.Testing.AutoFixture;
-using System.Threading.Tasks;
 
 namespace SFA.DAS.CommitmentsV2.Jobs.UnitTests.ScheduledJobs
 {
@@ -20,7 +21,7 @@ namespace SFA.DAS.CommitmentsV2.Jobs.UnitTests.ScheduledJobs
             await sut.Update(null);
 
             //Assert
-            dataLockUpdaterService.Verify(m => m.RunUpdate(), Times.Once);
+            dataLockUpdaterService.Verify(m => m.RunUpdate(It.IsAny<CancellationToken>()), Times.Once);
         }
     }
 }

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Jobs.UnitTests/ScheduledJobs/DataLockUpdaterJobsTests.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Jobs.UnitTests/ScheduledJobs/DataLockUpdaterJobsTests.cs
@@ -21,7 +21,7 @@ namespace SFA.DAS.CommitmentsV2.Jobs.UnitTests.ScheduledJobs
             await sut.Update(null);
 
             //Assert
-            dataLockUpdaterService.Verify(m => m.RunUpdate(It.IsAny<CancellationToken>()), Times.Once);
+            dataLockUpdaterService.Verify(m => m.RunUpdate(), Times.Once);
         }
     }
 }

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Jobs/ScheduledJobs/DataLockUpdaterJobs.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Jobs/ScheduledJobs/DataLockUpdaterJobs.cs
@@ -1,10 +1,7 @@
-﻿using Microsoft.Azure.WebJobs;
+﻿using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
 using SFA.DAS.CommitmentsV2.Domain.Interfaces;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SFA.DAS.CommitmentsV2.Jobs.ScheduledJobs
 {
@@ -19,7 +16,7 @@ namespace SFA.DAS.CommitmentsV2.Jobs.ScheduledJobs
             _dataLockUpdaterServicer = dataLockUpdaterServicer;
         }
 
-        public async Task Update([TimerTrigger("*/30 * * * * *", RunOnStartup = true)] TimerInfo timer)
+        public async Task Update([TimerTrigger("0 * * 29 2 *", RunOnStartup = true)] TimerInfo timer)
         {
             _logger.LogInformation($"DataLockUpdaterJobs - Started{(timer?.IsPastDue ?? false ? " later than expected" : string.Empty)}");
 

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Jobs/ScheduledJobs/DataLockUpdaterJobs.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2.Jobs/ScheduledJobs/DataLockUpdaterJobs.cs
@@ -16,7 +16,7 @@ namespace SFA.DAS.CommitmentsV2.Jobs.ScheduledJobs
             _dataLockUpdaterServicer = dataLockUpdaterServicer;
         }
 
-        public async Task Update([TimerTrigger("0 * * 29 2 *", RunOnStartup = true)] TimerInfo timer)
+        public async Task Update([TimerTrigger("0 */20 * * * *", RunOnStartup = true)] TimerInfo timer)
         {
             _logger.LogInformation($"DataLockUpdaterJobs - Started{(timer?.IsPastDue ?? false ? " later than expected" : string.Empty)}");
 

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2.UnitTests/Services/DataLockUpdaterServiceTests.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2.UnitTests/Services/DataLockUpdaterServiceTests.cs
@@ -32,12 +32,14 @@ namespace SFA.DAS.CommitmentsV2.UnitTests.Services
         private Mock<IFilterOutAcademicYearRollOverDataLocks> _filterOutAcademicYearRollOverDataLocks;
         private Fixture _fixture;
         private DataLockUpdaterService _dataLockUpdater;
+        private long _seedDataLockEventId;
 
         public string LegalEntityIdentifier;
         public OrganisationType organisationType;
         public List<Apprenticeship> SeedApprenticeships;
         public List<DataLockStatus> SeedDataLocks;
         public List<ApprenticeshipUpdate> SeedApprenticeshipUpdates;
+
 
         [SetUp]
         public void Arrange()
@@ -56,6 +58,8 @@ namespace SFA.DAS.CommitmentsV2.UnitTests.Services
                  .EnableSensitiveDataLogging()
                  .ConfigureWarnings(w => w.Ignore(CoreEventId.ManyServiceProvidersCreatedWarning))
                  .Options);
+
+            _seedDataLockEventId = 1;
 
             SeedApprenticeship(1, PaymentStatus.Active);
             SeedApprenticeshipUpdate(SeedApprenticeships[0].Id, PaymentStatus.Active, SeedApprenticeships[0]);
@@ -133,7 +137,7 @@ namespace SFA.DAS.CommitmentsV2.UnitTests.Services
             };
 
             _outerApiClient
-               .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.IsAny<GetDataLockEventsRequest>()))
+               .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.Is<GetDataLockEventsRequest>(x => x.SinceEventId == _seedDataLockEventId)))
                .ReturnsAsync(apimResponse);
 
             //Act
@@ -166,23 +170,29 @@ namespace SFA.DAS.CommitmentsV2.UnitTests.Services
                dataLockEventId4, dataLockEventId4, "TEST-15/08/2020", DateTime.Now, DataLockErrorCode.Dlock03,
                SeedApprenticeshipUpdates.FirstOrDefault(), dataLockResolved);
 
-            var apimResponse = new GetDataLockStatusListResponse
-            {
-                DataLockStatuses = Clone(SeedDataLocks)
-            };
-
             SeedDataLocks.ForEach(x => x.IsResolved = false);
             SeedData(Db);
 
+            SeedDataLocks.ForEach(dl =>
+            {
+                dl.DataLockEventId = dl.DataLockEventId + 3;
+                dl.IsResolved = true;
+            });
+
+            var apimResponse = new GetDataLockStatusListResponse
+            {
+                DataLockStatuses = SeedDataLocks
+            };
+
             _outerApiClient
-               .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.IsAny<GetDataLockEventsRequest>()))
+               .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.Is<GetDataLockEventsRequest>(x => x.SinceEventId == 4)))
                .ReturnsAsync(apimResponse);
 
             //Act
             await _dataLockUpdater.RunUpdate();
 
             //Assert
-            VerifyDataLockIsResolved(new List<long> { dataLockEventId2, dataLockEventId3, dataLockEventId4 });
+            VerifyDataLockIsResolved(new List<long> { dataLockEventId2 + 3, dataLockEventId3 + 3, dataLockEventId4 + 3});
         }
 
         [Test]
@@ -202,15 +212,17 @@ namespace SFA.DAS.CommitmentsV2.UnitTests.Services
             SeedApprenticeshipUpdate(SeedApprenticeships[2].Id, PaymentStatus.Active, SeedApprenticeships[2]);
             SeedDataLock(SeedApprenticeships[2], 2, 2, "TEST-15/08/2018", new DateTime(2018, 8, 1), DataLockErrorCode.None, SeedApprenticeshipUpdates[2]);
 
+            SeedData(Db);
+
+            SeedDataLocks.ForEach(dl => dl.DataLockEventId = dl.DataLockEventId + 1);
+
             var apimResponse = new GetDataLockStatusListResponse
             {
                 DataLockStatuses = SeedDataLocks
-            };
-
-            SeedData(Db);
+            };          
 
             _outerApiClient
-             .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.IsAny<GetDataLockEventsRequest>()))
+             .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.Is<GetDataLockEventsRequest>(x => x.SinceEventId == 2)))
              .ReturnsAsync(apimResponse);
 
             //Act
@@ -251,7 +263,7 @@ namespace SFA.DAS.CommitmentsV2.UnitTests.Services
             };
 
             _outerApiClient
-               .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.IsAny<GetDataLockEventsRequest>()))
+               .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.Is<GetDataLockEventsRequest>(x => x.SinceEventId == _seedDataLockEventId)))
                .ReturnsAsync(apimResponse);
 
             //Act
@@ -280,7 +292,7 @@ namespace SFA.DAS.CommitmentsV2.UnitTests.Services
             };
 
             _outerApiClient
-               .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.IsAny<GetDataLockEventsRequest>()))
+               .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.Is<GetDataLockEventsRequest>(x => x.SinceEventId == _seedDataLockEventId)))
                .ReturnsAsync(apimResponse);
 
             //Act
@@ -308,13 +320,15 @@ namespace SFA.DAS.CommitmentsV2.UnitTests.Services
             SeedDataLock(SeedApprenticeships.First(), objectId, objectId, "TEST-15/08/2018", new DateTime(2018, 8, 1), errorCode, SeedApprenticeshipUpdates.First());
             SeedData(Db);
 
+            SeedDataLocks.ForEach(dl => dl.DataLockEventId = dl.DataLockEventId + 1);
+
             var apimResponse = new GetDataLockStatusListResponse
             {
                 DataLockStatuses = SeedDataLocks
             };
 
             _outerApiClient
-               .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.IsAny<GetDataLockEventsRequest>()))
+               .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.Is<GetDataLockEventsRequest>(x => x.SinceEventId == objectId)))
                .ReturnsAsync(apimResponse);
 
             //Act
@@ -362,7 +376,7 @@ namespace SFA.DAS.CommitmentsV2.UnitTests.Services
             };
 
             _outerApiClient
-               .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.IsAny<GetDataLockEventsRequest>()))
+               .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.Is<GetDataLockEventsRequest>(x => x.SinceEventId == _seedDataLockEventId)))
                .ReturnsAsync(apimResponse);
 
             //Act
@@ -403,7 +417,7 @@ namespace SFA.DAS.CommitmentsV2.UnitTests.Services
             SeedData(Db);
 
             _outerApiClient
-               .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.IsAny<GetDataLockEventsRequest>()))
+               .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.Is<GetDataLockEventsRequest>(x => x.SinceEventId == _seedDataLockEventId)))
                .ReturnsAsync(apimResponse);
 
             //Act
@@ -445,7 +459,7 @@ namespace SFA.DAS.CommitmentsV2.UnitTests.Services
             };
 
             _outerApiClient
-                .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.IsAny<GetDataLockEventsRequest>()))
+                .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.Is<GetDataLockEventsRequest>(x => x.SinceEventId == _seedDataLockEventId)))
                 .ReturnsAsync(apimResponse);
 
             //Act
@@ -475,7 +489,7 @@ namespace SFA.DAS.CommitmentsV2.UnitTests.Services
             };
 
             _outerApiClient
-               .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.IsAny<GetDataLockEventsRequest>()))
+               .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.Is<GetDataLockEventsRequest>(x => x.SinceEventId == _seedDataLockEventId)))
                .ReturnsAsync(apimResponse);
 
             //Act
@@ -584,12 +598,6 @@ namespace SFA.DAS.CommitmentsV2.UnitTests.Services
                 _outerApiClient.Object,
                new CommitmentPaymentsWebJobConfiguration(),
                Mock.Of<IFilterOutAcademicYearRollOverDataLocks>());
-        }
-
-        private T Clone<T>(T objectToClone)
-        {
-            var stringValue = JsonConvert.SerializeObject(objectToClone);
-            return JsonConvert.DeserializeObject<T>(stringValue);
         }
 
         private void VerifyDataLockIsResolved(List<long> dataLockEventIds)

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2.UnitTests/Services/DataLockUpdaterServiceTests.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2.UnitTests/Services/DataLockUpdaterServiceTests.cs
@@ -390,44 +390,44 @@ namespace SFA.DAS.CommitmentsV2.UnitTests.Services
             Assert.IsTrue(apprenticeshipUpdate.Status == ApprenticeshipUpdateStatus.Pending);
         }
 
-        //[Test]
-        //public async Task ThenDatalocksForStoppedAndBackdatedApprenticeshipsAreAutoResolved()
-        //{
-        //    //Arange
-        //    SeedDataLocks.Clear();
+        [Test]
+        public async Task ThenDatalocksForStoppedAndBackdatedApprenticeshipsAreAutoResolved()
+        {
+            //Arange
+            SeedDataLocks.Clear();
 
-        //    long dataLockEventId2 = 2;
-        //    var dataLockResolved = false;
+            long dataLockEventId2 = 2;
+            var dataLockResolved = false;
 
-        //    SeedApprenticeships[0].PaymentStatus = PaymentStatus.Withdrawn;
-        //    SeedApprenticeships[0].StartDate = DateTime.Today.AddMonths(-1);
-        //    SeedApprenticeships[0].StopDate = DateTime.Today.AddMonths(-1);
+            SeedApprenticeships[0].PaymentStatus = PaymentStatus.Withdrawn;
+            SeedApprenticeships[0].StartDate = DateTime.Today.AddMonths(-1);
+            SeedApprenticeships[0].StopDate = DateTime.Today.AddMonths(-1);
 
-        //    SeedDataLock(SeedApprenticeships[0],
-        //        dataLockEventId2, dataLockEventId2, "TEST-15/08/2018",
-        //        DateTime.Now,
-        //        DataLockErrorCode.Dlock07,
-        //        SeedApprenticeshipUpdates.FirstOrDefault(), dataLockResolved);
+            SeedDataLock(SeedApprenticeships[0],
+                dataLockEventId2, dataLockEventId2, "TEST-15/08/2018",
+                DateTime.Now,
+                DataLockErrorCode.Dlock07,
+                SeedApprenticeshipUpdates.FirstOrDefault(), dataLockResolved);
 
-        //    SeedData(Db);
+            SeedData(Db);
 
-        //    SeedDataLocks.ForEach(dl => dl.DataLockEventId = dl.DataLockEventId + 3);
+            SeedDataLocks.ForEach(dl => dl.DataLockEventId = dl.DataLockEventId + 3);
 
-        //    var apimResponse = new GetDataLockStatusListResponse
-        //    {
-        //        DataLockStatuses = SeedDataLocks
-        //    };
+            var apimResponse = new GetDataLockStatusListResponse
+            {
+                DataLockStatuses = SeedDataLocks
+            };
 
-        //    _outerApiClient
-        //       .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.Is<GetDataLockEventsRequest>(x => x.SinceEventId == dataLockEventId2)))
-        //       .ReturnsAsync(apimResponse);
+            _outerApiClient
+               .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.Is<GetDataLockEventsRequest>(x => x.SinceEventId == dataLockEventId2)))
+               .ReturnsAsync(apimResponse);
 
-        //    //Act
-        //    await _dataLockUpdater.RunUpdate();
+            //Act
+            await _dataLockUpdater.RunUpdate();
 
-        //    //Assert
-        //    VerifyDataLockIsResolved(new List<long> { dataLockEventId2 });
-        //}
+            //Assert
+            VerifyDataLockIsResolved(new List<long> { dataLockEventId2 + 3 });
+        }
 
         [Test]
         public async Task ThenPriceDatalocksInCombinationWithDlock09AreIgnored()

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2.UnitTests/Services/DataLockUpdaterServiceTests.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2.UnitTests/Services/DataLockUpdaterServiceTests.cs
@@ -390,42 +390,44 @@ namespace SFA.DAS.CommitmentsV2.UnitTests.Services
             Assert.IsTrue(apprenticeshipUpdate.Status == ApprenticeshipUpdateStatus.Pending);
         }
 
-        [Test]
-        public async Task ThenDatalocksForStoppedAndBackdatedApprenticeshipsAreAutoResolved()
-        {
-            //Arange
-            SeedDataLocks.Clear();
+        //[Test]
+        //public async Task ThenDatalocksForStoppedAndBackdatedApprenticeshipsAreAutoResolved()
+        //{
+        //    //Arange
+        //    SeedDataLocks.Clear();
 
-            long dataLockEventId2 = 2;
-            var dataLockResolved = false;
+        //    long dataLockEventId2 = 2;
+        //    var dataLockResolved = false;
 
-            SeedApprenticeships[0].PaymentStatus = PaymentStatus.Withdrawn;
-            SeedApprenticeships[0].StartDate = DateTime.Today.AddMonths(-1);
-            SeedApprenticeships[0].StopDate = DateTime.Today.AddMonths(-1);
+        //    SeedApprenticeships[0].PaymentStatus = PaymentStatus.Withdrawn;
+        //    SeedApprenticeships[0].StartDate = DateTime.Today.AddMonths(-1);
+        //    SeedApprenticeships[0].StopDate = DateTime.Today.AddMonths(-1);
 
-            SeedDataLock(SeedApprenticeships[0],
-                dataLockEventId2, dataLockEventId2, "TEST-15/08/2018",
-                DateTime.Now,
-                DataLockErrorCode.Dlock07,
-                SeedApprenticeshipUpdates.FirstOrDefault(), dataLockResolved);
+        //    SeedDataLock(SeedApprenticeships[0],
+        //        dataLockEventId2, dataLockEventId2, "TEST-15/08/2018",
+        //        DateTime.Now,
+        //        DataLockErrorCode.Dlock07,
+        //        SeedApprenticeshipUpdates.FirstOrDefault(), dataLockResolved);
 
-            var apimResponse = new GetDataLockStatusListResponse
-            {
-                DataLockStatuses = SeedDataLocks
-            };
+        //    SeedData(Db);
 
-            SeedData(Db);
+        //    SeedDataLocks.ForEach(dl => dl.DataLockEventId = dl.DataLockEventId + 3);
 
-            _outerApiClient
-               .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.Is<GetDataLockEventsRequest>(x => x.SinceEventId == _seedDataLockEventId)))
-               .ReturnsAsync(apimResponse);
+        //    var apimResponse = new GetDataLockStatusListResponse
+        //    {
+        //        DataLockStatuses = SeedDataLocks
+        //    };
 
-            //Act
-            await _dataLockUpdater.RunUpdate();
+        //    _outerApiClient
+        //       .Setup(x => x.GetWithRetry<GetDataLockStatusListResponse>(It.Is<GetDataLockEventsRequest>(x => x.SinceEventId == dataLockEventId2)))
+        //       .ReturnsAsync(apimResponse);
 
-            //Assert
-            VerifyDataLockIsResolved(new List<long> { dataLockEventId2 });
-        }
+        //    //Act
+        //    await _dataLockUpdater.RunUpdate();
+
+        //    //Assert
+        //    VerifyDataLockIsResolved(new List<long> { dataLockEventId2 });
+        //}
 
         [Test]
         public async Task ThenPriceDatalocksInCombinationWithDlock09AreIgnored()

--- a/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Services/DataLockUpdaterService.cs
+++ b/src/CommitmentsV2/SFA.DAS.CommitmentsV2/Services/DataLockUpdaterService.cs
@@ -57,85 +57,88 @@ namespace SFA.DAS.CommitmentsV2.Services
             _logger.LogInformation("Retrieving last DataLock Event Id from repository");
             var lastId = await GetLastDataLockEventId();
 
-            _logger.LogInformation($"Retrieving page of data from Payment Events Service since Event Id {lastId}");
-            var stopwatch = Stopwatch.StartNew();
-
-            var datalockStatusResponse = await _outerApiClient.GetWithRetry<GetDataLockStatusListResponse>(new GetDataLockEventsRequest(lastId));
-
-            var page = datalockStatusResponse?.DataLockStatuses ?? new List<DataLockStatus>();
-
-            stopwatch.Stop();
-            _logger.LogInformation($"Response took {stopwatch.ElapsedMilliseconds}ms");
-
-            if (!page.Any())
+            while (true)
             {
-                _logger.LogInformation("No data returned; exiting");
-                return;
-            }
+                _logger.LogInformation($"Retrieving page of data from Payment Events Service since Event Id {lastId}");
+                var stopwatch = Stopwatch.StartNew();
 
-            _logger.LogInformation($"{page.Count()} records returned in page");
+                var datalockStatusResponse = await _outerApiClient.GetWithRetry<GetDataLockStatusListResponse>(new GetDataLockEventsRequest(lastId));
 
-            foreach (var dataLockStatus in page)
-            {
-                _logger.LogInformation($"Read datalock Apprenticeship {dataLockStatus.ApprenticeshipId} " +
-                    $"Event Id {dataLockStatus.DataLockEventId} Status {dataLockStatus.ErrorCode} and EventStatus: {dataLockStatus.EventStatus}");
+                var page = datalockStatusResponse?.DataLockStatuses ?? new List<DataLockStatus>();
 
-                var datalockSuccess = dataLockStatus.ErrorCode == DataLockErrorCode.None;
+                stopwatch.Stop();
+                _logger.LogInformation($"Response took {stopwatch.ElapsedMilliseconds}ms");
 
-                if (!datalockSuccess)
+                if (!page.Any())
                 {
-                    ApplyErrorCodeWhiteList(dataLockStatus);
+                    _logger.LogInformation("No data returned; exiting");
+                    return;
                 }
 
-                var is1617 = GetDateFromPriceEpisodeIdentifier(dataLockStatus) < _1718AcademicYearStartDate;
-                if (is1617)
-                {
-                    _logger.LogInformation($"Data lock Event Id {dataLockStatus.DataLockEventId} pertains to 16/17 academic year and will be ignored");
-                }
+                _logger.LogInformation($"{page.Count()} records returned in page");
 
-                if ((datalockSuccess || dataLockStatus.ErrorCode != DataLockErrorCode.None) && !is1617)
+                foreach (var dataLockStatus in page)
                 {
-                    var apprenticeship = await GetApprenticeship(dataLockStatus.ApprenticeshipId);
+                    _logger.LogInformation($"Read datalock Apprenticeship {dataLockStatus.ApprenticeshipId} " +
+                        $"Event Id {dataLockStatus.DataLockEventId} Status {dataLockStatus.ErrorCode} and EventStatus: {dataLockStatus.EventStatus}");
 
-                    //temporarily ignore dlock7 & 9 combos until payments R14 fixes properly
-                    if (dataLockStatus.ErrorCode.HasFlag(DataLockErrorCode.Dlock07) && dataLockStatus.IlrEffectiveFromDate < apprenticeship.StartDate)
+                    var datalockSuccess = dataLockStatus.ErrorCode == DataLockErrorCode.None;
+
+                    if (!datalockSuccess)
                     {
-                        _logger.LogInformation($"Ignoring datalock for Apprenticeship #{dataLockStatus.ApprenticeshipId} Dlock07 with Effective Date before Start Date. Event Id {dataLockStatus.DataLockEventId}");
+                        ApplyErrorCodeWhiteList(dataLockStatus);
                     }
-                    else
+
+                    var is1617 = GetDateFromPriceEpisodeIdentifier(dataLockStatus) < _1718AcademicYearStartDate;
+                    if (is1617)
                     {
-                        _logger.LogInformation($"Updating Apprenticeship {dataLockStatus.ApprenticeshipId} " +
-                                     $"Event Id {dataLockStatus.DataLockEventId} Status {dataLockStatus.ErrorCode}");
+                        _logger.LogInformation($"Data lock Event Id {dataLockStatus.DataLockEventId} pertains to 16/17 academic year and will be ignored");
+                    }
 
-                        AutoResolveDataLockIfApprenticeshipStoppedAndBackdated(apprenticeship, dataLockStatus);
+                    if ((datalockSuccess || dataLockStatus.ErrorCode != DataLockErrorCode.None) && !is1617)
+                    {
+                        var apprenticeship = await GetApprenticeship(dataLockStatus.ApprenticeshipId);
 
-                        try
+                        //temporarily ignore dlock7 & 9 combos until payments R14 fixes properly
+                        if (dataLockStatus.ErrorCode.HasFlag(DataLockErrorCode.Dlock07) && dataLockStatus.IlrEffectiveFromDate < apprenticeship.StartDate)
                         {
-                            await UpdateDataLockStatus(dataLockStatus);
-
-                            await _filterOutAcademicYearRollOverDataLocks.Filter(dataLockStatus.ApprenticeshipId);
+                            _logger.LogInformation($"Ignoring datalock for Apprenticeship #{dataLockStatus.ApprenticeshipId} Dlock07 with Effective Date before Start Date. Event Id {dataLockStatus.DataLockEventId}");
                         }
-                        catch (RepositoryConstraintException ex) when (_config.IgnoreDataLockStatusConstraintErrors)
+                        else
                         {
-                            _logger.LogWarning(ex, $"Exception in DataLock updater");
-                        }
+                            _logger.LogInformation($"Updating Apprenticeship {dataLockStatus.ApprenticeshipId} " +
+                                         $"Event Id {dataLockStatus.DataLockEventId} Status {dataLockStatus.ErrorCode}");
 
-                        if (datalockSuccess)
-                        {
-                            await SetHasHadDataLockSuccess(dataLockStatus.ApprenticeshipId);
+                            AutoResolveDataLockIfApprenticeshipStoppedAndBackdated(apprenticeship, dataLockStatus);
 
-                            var pendingUpdate = await GetPendingApprenticeshipUpdate(dataLockStatus.ApprenticeshipId);
-
-                            if (pendingUpdate != null && (pendingUpdate.Cost != null || pendingUpdate.TrainingCode != null))
+                            try
                             {
-                                await ExpireApprenticeshipUpdate(pendingUpdate.Id);
-                                _logger.LogInformation($"Pending ApprenticeshipUpdate {pendingUpdate.Id} expired due to successful data lock event {dataLockStatus.DataLockEventId}");
+                                await UpdateDataLockStatus(dataLockStatus);
+
+                                await _filterOutAcademicYearRollOverDataLocks.Filter(dataLockStatus.ApprenticeshipId);
+                            }
+                            catch (RepositoryConstraintException ex) when (_config.IgnoreDataLockStatusConstraintErrors)
+                            {
+                                _logger.LogWarning(ex, $"Exception in DataLock updater");
+                            }
+
+                            if (datalockSuccess)
+                            {
+                                await SetHasHadDataLockSuccess(dataLockStatus.ApprenticeshipId);
+
+                                var pendingUpdate = await GetPendingApprenticeshipUpdate(dataLockStatus.ApprenticeshipId);
+
+                                if (pendingUpdate != null && (pendingUpdate.Cost != null || pendingUpdate.TrainingCode != null))
+                                {
+                                    await ExpireApprenticeshipUpdate(pendingUpdate.Id);
+                                    _logger.LogInformation($"Pending ApprenticeshipUpdate {pendingUpdate.Id} expired due to successful data lock event {dataLockStatus.DataLockEventId}");
+                                }
                             }
                         }
                     }
-                }
 
-                lastId = dataLockStatus.DataLockEventId;
+                    lastId = dataLockStatus.DataLockEventId;
+                }
             }
         }
 


### PR DESCRIPTION
… entire page of responses from Payments api results in no new DLOCKs added to the DB in which case the same page will be requested continuously

this is how the code worked prior to being moved to V2